### PR TITLE
feat: add admin endpoint for real-time CPU and memory stats

### DIFF
--- a/src/Agents/registry/ToolRegistry.ts
+++ b/src/Agents/registry/ToolRegistry.ts
@@ -98,54 +98,6 @@ export class ToolRegistry {
 
     this.categories.add(tool.metadata.category);
   }
-  /**
-   * Register a custom tool dynamically without modifying core registry
-   * This allows external tools to be added at runtime
-   */
-  registerCustomTool<T extends ToolPayload>(
-    tool: ToolDefinition<T>,
-    options?: {
-      overwrite?: boolean;
-      namespace?: string;
-    }
-  ): void {
-    const { metadata } = tool;
-    let toolName = metadata.name;
-
-    // Apply namespace if provided
-    if (options?.namespace) {
-      toolName = `${options.namespace}:${toolName}`;
-      // Create a new metadata object with namespaced name
-      tool = {
-        ...tool,
-        metadata: {
-          ...metadata,
-          name: toolName,
-        },
-      };
-    }
-
-    // Check if tool already exists
-    if (this.tools.has(toolName)) {
-      if (!options?.overwrite) {
-        throw new Error(
-          `Tool '${toolName}' is already registered. Use overwrite option to replace it.`
-        );
-      }
-      // Unregister existing tool first
-      this.unregister(toolName);
-    }
-
-    this.validateToolMetadata(tool.metadata);
-
-    this.tools.set(toolName, {
-      name: toolName,
-      definition: tool as ToolDefinition,
-      enabled: true,
-    });
-
-    this.categories.add(tool.metadata.category);
-  }
 
   /**
    * Register multiple custom tools at once

--- a/src/Gateway/routes.ts
+++ b/src/Gateway/routes.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from "express";
 import { rateLimit } from "express-rate-limit";
 import helmet from "helmet";
+import * as os from "os";
 import AppDataSource from "../config/Datasource";
 import { User } from "../Auth/user.entity";
 import { stellarWebhookService } from "./webhook.service";
@@ -218,5 +219,36 @@ router.get(
     }
   })
 );
+
+// GET /admin/stats - Internal admin route for CPU and memory usage
+router.get("/admin/stats", (req: Request, res: Response) => {
+  const memUsage = process.memoryUsage();
+  const cpuUsage = process.cpuUsage();
+
+  res.json({
+    success: true,
+    timestamp: new Date().toISOString(),
+    memory: {
+      rss: `${(memUsage.rss / 1024 / 1024).toFixed(2)} MB`,
+      heapTotal: `${(memUsage.heapTotal / 1024 / 1024).toFixed(2)} MB`,
+      heapUsed: `${(memUsage.heapUsed / 1024 / 1024).toFixed(2)} MB`,
+      external: `${(memUsage.external / 1024 / 1024).toFixed(2)} MB`,
+    },
+    cpu: {
+      user: `${(cpuUsage.user / 1000).toFixed(2)} ms`,
+      system: `${(cpuUsage.system / 1000).toFixed(2)} ms`,
+    },
+    system: {
+      totalMemory: `${(os.totalmem() / 1024 / 1024 / 1024).toFixed(2)} GB`,
+      freeMemory: `${(os.freemem() / 1024 / 1024 / 1024).toFixed(2)} GB`,
+      uptime: `${(os.uptime() / 3600).toFixed(2)} hours`,
+      loadAverage: os.loadavg(),
+    },
+    process: {
+      uptime: `${(process.uptime() / 60).toFixed(2)} minutes`,
+      pid: process.pid,
+    },
+  });
+});
 
 export default router;


### PR DESCRIPTION
Closes #79 

 ## Admin Stats Endpoint

Added internal admin route GET /api/admin/stats that returns real-time CPU and 
memory usage statistics for the backend process.

Endpoint: http://localhost:2333/api/admin/stats

Response includes:
- Process memory usage (RSS, heap, external)
- CPU usage (user/system time)
- System stats (total/free memory, uptime, load average)
- Process info (uptime, PID)

Changes:
- Added /admin/stats route in src/Gateway/routes.ts
- Fixed duplicate function in ToolRegistry.ts (blocking server startup)
