### PR TITLE
eat(sdk): add client-side idempotency keys for BTC→Stellar swap retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,45 @@ The agent uses an intelligent workflow system that:
 
 ---
 
+## SDK Idempotency for BTC → Stellar Swaps
+
+Use the SDK idempotency helpers to guarantee retries do not create duplicate intents.
+
+```ts
+import {
+  AgentClient,
+  createBtcToStellarSwapIdempotencyKey,
+  ChainId,
+} from "@chen-pilot/sdk-core";
+
+const client = new AgentClient({ baseUrl: "https://your-chenpilot-api" });
+
+const swapRequest = {
+  fromChain: ChainId.BITCOIN,
+  toChain: ChainId.STELLAR,
+  fromToken: "BTC",
+  toToken: "XLM",
+  amount: "0.01",
+  destinationAddress: "G...",
+};
+
+// Generate once, persist in your app state, and reuse on retries
+const idempotencyKey = createBtcToStellarSwapIdempotencyKey(
+  swapRequest,
+  "wallet-action-123"
+);
+
+await client.executeBtcToStellarSwap(swapRequest, {
+  userId: "user-uuid",
+  idempotencyKey,
+  maxRetries: 3,
+});
+```
+
+If a timeout/network failure happens, call `executeBtcToStellarSwap` again with the same `idempotencyKey`.
+
+---
+
 ## Contributing
 
 - Fork the repository

--- a/packages/sdk/src/agentClient.ts
+++ b/packages/sdk/src/agentClient.ts
@@ -1,0 +1,322 @@
+import { createHash, randomUUID } from "crypto";
+import { AgentResponse, ChainId, CrossChainSwapRequest } from "./types";
+
+export interface IdempotencyKeyInput {
+  namespace: string;
+  payload: unknown;
+  clientRequestId?: string;
+}
+
+export interface AgentClientOptions {
+  baseUrl: string;
+  defaultTimeoutMs?: number;
+  defaultMaxRetries?: number;
+  defaultRetryDelayMs?: number;
+  fetchFn?: FetchLike;
+}
+
+interface AbortSignalLike {
+  aborted: boolean;
+  addEventListener?: (
+    type: "abort",
+    listener: () => void,
+    options?: { once?: boolean }
+  ) => void;
+}
+
+interface AbortControllerLike {
+  signal: AbortSignalLike;
+  abort: () => void;
+}
+
+export interface AgentQueryRequest {
+  userId: string;
+  query: string;
+  idempotencyKey?: string;
+  timeoutMs?: number;
+  maxRetries?: number;
+  retryDelayMs?: number;
+  signal?: AbortSignalLike;
+}
+
+export interface AgentQueryResult<T = AgentResponse> {
+  idempotencyKey: string;
+  attempts: number;
+  result: T;
+}
+
+export interface ExecuteBtcToStellarSwapOptions {
+  userId: string;
+  idempotencyKey?: string;
+  timeoutMs?: number;
+  maxRetries?: number;
+  retryDelayMs?: number;
+  signal?: AbortSignalLike;
+}
+
+export class AgentRequestError extends Error {
+  readonly idempotencyKey: string;
+  readonly attempts: number;
+  readonly statusCode?: number;
+
+  constructor(
+    message: string,
+    idempotencyKey: string,
+    attempts: number,
+    statusCode?: number
+  ) {
+    super(message);
+    this.name = "AgentRequestError";
+    this.idempotencyKey = idempotencyKey;
+    this.attempts = attempts;
+    this.statusCode = statusCode;
+  }
+}
+
+interface QueryEnvelope<T = unknown> {
+  result: T;
+}
+
+interface FetchResponseLike {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+type FetchLike = (
+  input: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignalLike;
+  }
+) => Promise<FetchResponseLike>;
+
+const RETRIABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => canonicalize(item));
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const obj = value as Record<string, unknown>;
+  return Object.keys(obj)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      acc[key] = canonicalize(obj[key]);
+      return acc;
+    }, {});
+}
+
+export function generateIdempotencyKey({
+  namespace,
+  payload,
+  clientRequestId,
+}: IdempotencyKeyInput): string {
+  const fingerprint = createHash("sha256")
+    .update(JSON.stringify(canonicalize(payload)))
+    .digest("hex")
+    .slice(0, 24);
+
+  const requestId = clientRequestId ?? randomUUID();
+  return `${namespace}:${fingerprint}:${requestId}`;
+}
+
+export function createBtcToStellarSwapIdempotencyKey(
+  request: CrossChainSwapRequest,
+  clientRequestId?: string
+): string {
+  return generateIdempotencyKey({
+    namespace: "swap-btc-stellar",
+    payload: request,
+    clientRequestId,
+  });
+}
+
+function toSwapQuery(request: CrossChainSwapRequest): string {
+  return [
+    `Swap ${request.amount} ${request.fromToken}`,
+    `from ${request.fromChain}`,
+    `to ${request.toToken} on ${request.toChain}`,
+    `for destination ${request.destinationAddress}`,
+  ].join(" ");
+}
+
+function createTimedSignal(timeoutMs: number, externalSignal?: AbortSignalLike) {
+  const controller = new AbortController() as unknown as AbortControllerLike;
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  if (externalSignal) {
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else {
+      externalSignal.addEventListener?.("abort", () => controller.abort(), {
+        once: true,
+      });
+    }
+  }
+
+  return {
+    signal: controller.signal,
+    clear: () => clearTimeout(timeoutId),
+  };
+}
+
+export class AgentClient {
+  private readonly baseUrl: string;
+  private readonly defaultTimeoutMs: number;
+  private readonly defaultMaxRetries: number;
+  private readonly defaultRetryDelayMs: number;
+  private readonly fetchFn: FetchLike;
+
+  constructor(options: AgentClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.defaultTimeoutMs = options.defaultTimeoutMs ?? 15_000;
+    this.defaultMaxRetries = options.defaultMaxRetries ?? 3;
+    this.defaultRetryDelayMs = options.defaultRetryDelayMs ?? 500;
+    const runtimeFetch =
+      (globalThis as unknown as { fetch?: FetchLike }).fetch;
+    const selectedFetch = options.fetchFn ?? runtimeFetch;
+
+    if (!selectedFetch) {
+      throw new Error("No fetch implementation available for AgentClient");
+    }
+
+    this.fetchFn = selectedFetch;
+  }
+
+  async query<T = AgentResponse>(
+    request: AgentQueryRequest
+  ): Promise<AgentQueryResult<T>> {
+    const idempotencyKey =
+      request.idempotencyKey ??
+      generateIdempotencyKey({
+        namespace: "agent-query",
+        payload: {
+          userId: request.userId,
+          query: request.query,
+        },
+      });
+
+    const maxRetries = request.maxRetries ?? this.defaultMaxRetries;
+    const timeoutMs = request.timeoutMs ?? this.defaultTimeoutMs;
+    const retryDelayMs = request.retryDelayMs ?? this.defaultRetryDelayMs;
+
+    let attempts = 0;
+    let lastErrorMessage = "Request failed";
+    let lastStatusCode: number | undefined;
+
+    while (attempts < maxRetries) {
+      attempts += 1;
+      const timedSignal = createTimedSignal(timeoutMs, request.signal);
+
+      try {
+        const response = await this.fetchFn(`${this.baseUrl}/query`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Idempotency-Key": idempotencyKey,
+          },
+          body: JSON.stringify({ userId: request.userId, query: request.query }),
+          signal: timedSignal.signal,
+        });
+
+        if (!response.ok) {
+          lastStatusCode = response.status;
+          const body = await response.text().catch(() => "");
+          const message = body || `HTTP ${response.status}`;
+
+          if (!RETRIABLE_STATUS_CODES.has(response.status) || attempts >= maxRetries) {
+            throw new AgentRequestError(
+              `Agent query failed: ${message}`,
+              idempotencyKey,
+              attempts,
+              response.status
+            );
+          }
+
+          lastErrorMessage = `Agent query failed: ${message}`;
+          await sleep(retryDelayMs * attempts);
+          continue;
+        }
+
+        const parsed = (await response.json()) as QueryEnvelope<T>;
+        return {
+          idempotencyKey,
+          attempts,
+          result: parsed.result,
+        };
+      } catch (error) {
+        const isAbort =
+          error instanceof Error &&
+          (error.name === "AbortError" || error.message.includes("aborted"));
+        const isNetwork =
+          error instanceof TypeError ||
+          (error instanceof Error && error.message.toLowerCase().includes("network"));
+
+        if (error instanceof AgentRequestError) {
+          throw error;
+        }
+
+        lastErrorMessage = error instanceof Error ? error.message : String(error);
+
+        if (!(isAbort || isNetwork) || attempts >= maxRetries) {
+          throw new AgentRequestError(
+            `Agent query failed: ${lastErrorMessage}`,
+            idempotencyKey,
+            attempts,
+            lastStatusCode
+          );
+        }
+
+        await sleep(retryDelayMs * attempts);
+      } finally {
+        timedSignal.clear();
+      }
+    }
+
+    throw new AgentRequestError(
+      `Agent query failed: ${lastErrorMessage}`,
+      idempotencyKey,
+      attempts,
+      lastStatusCode
+    );
+  }
+
+  async executeBtcToStellarSwap<T = AgentResponse>(
+    swapRequest: CrossChainSwapRequest,
+    options: ExecuteBtcToStellarSwapOptions
+  ): Promise<AgentQueryResult<T>> {
+    if (
+      swapRequest.fromChain !== ChainId.BITCOIN ||
+      swapRequest.toChain !== ChainId.STELLAR
+    ) {
+      throw new Error(
+        "executeBtcToStellarSwap only supports fromChain=bitcoin and toChain=stellar"
+      );
+    }
+
+    const idempotencyKey =
+      options.idempotencyKey ?? createBtcToStellarSwapIdempotencyKey(swapRequest);
+
+    return this.query<T>({
+      userId: options.userId,
+      query: toSwapQuery(swapRequest),
+      idempotencyKey,
+      timeoutMs: options.timeoutMs,
+      maxRetries: options.maxRetries,
+      retryDelayMs: options.retryDelayMs,
+      signal: options.signal,
+    });
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./types";
 export * from "./recovery";
 export * from "./planVerification";
+export * from "./agentClient";

--- a/tests/unit/agent_client_idempotency.test.ts
+++ b/tests/unit/agent_client_idempotency.test.ts
@@ -1,0 +1,116 @@
+import {
+  AgentClient,
+  AgentRequestError,
+  createBtcToStellarSwapIdempotencyKey,
+  generateIdempotencyKey,
+} from "../../packages/sdk/src/agentClient";
+import { ChainId, CrossChainSwapRequest } from "../../packages/sdk/src/types";
+
+describe("AgentClient idempotency", () => {
+  const swapRequest: CrossChainSwapRequest = {
+    fromChain: ChainId.BITCOIN,
+    toChain: ChainId.STELLAR,
+    fromToken: "BTC",
+    toToken: "XLM",
+    amount: "0.01",
+    destinationAddress: "GDSTELLARDESTINATION",
+  };
+
+  it("generates deterministic fingerprint regardless of payload key order", () => {
+    const keyA = generateIdempotencyKey({
+      namespace: "swap-btc-stellar",
+      payload: {
+        a: 1,
+        b: { z: 2, y: [3, 4] },
+      },
+      clientRequestId: "req-123",
+    });
+
+    const keyB = generateIdempotencyKey({
+      namespace: "swap-btc-stellar",
+      payload: {
+        b: { y: [3, 4], z: 2 },
+        a: 1,
+      },
+      clientRequestId: "req-123",
+    });
+
+    expect(keyA).toBe(keyB);
+  });
+
+  it("reuses the same idempotency key across timeout/network retries", async () => {
+    const capturedHeaders: Array<Record<string, string> | undefined> = [];
+    const stableKey = createBtcToStellarSwapIdempotencyKey(
+      swapRequest,
+      "client-retry-id"
+    );
+
+    let calls = 0;
+    const client = new AgentClient({
+      baseUrl: "http://localhost:3000",
+      defaultRetryDelayMs: 0,
+      fetchFn: async (_url, init) => {
+        capturedHeaders.push(init?.headers);
+        calls += 1;
+
+        if (calls === 1) {
+          throw new TypeError("network error");
+        }
+
+        if (calls === 2) {
+          return {
+            ok: false,
+            status: 503,
+            json: async () => ({ result: {} }),
+            text: async () => "temporary unavailable",
+          };
+        }
+
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ result: { success: true, message: "ok" } }),
+          text: async () => "",
+        };
+      },
+    });
+
+    const result = await client.executeBtcToStellarSwap(swapRequest, {
+      userId: "user-1",
+      idempotencyKey: stableKey,
+      maxRetries: 3,
+    });
+
+    expect(result.idempotencyKey).toBe(stableKey);
+    expect(result.attempts).toBe(3);
+    expect(capturedHeaders).toHaveLength(3);
+
+    for (const headers of capturedHeaders) {
+      expect(headers?.["Idempotency-Key"]).toBe(stableKey);
+    }
+  });
+
+  it("surfaces idempotency key when retries are exhausted", async () => {
+    const providedKey = "swap-btc-stellar:fingerprint:req-999";
+
+    const client = new AgentClient({
+      baseUrl: "http://localhost:3000",
+      defaultRetryDelayMs: 0,
+      fetchFn: async () => {
+        throw new TypeError("network disconnected");
+      },
+    });
+
+    await expect(
+      client.executeBtcToStellarSwap(swapRequest, {
+        userId: "user-1",
+        idempotencyKey: providedKey,
+        maxRetries: 2,
+      })
+    ).rejects.toMatchObject<Partial<AgentRequestError>>({
+      name: "AgentRequestError",
+      idempotencyKey: providedKey,
+      attempts: 2,
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces an SDK-side idempotency protocol for agent calls used in BTC-to-Stellar swap workflows.
If a request times out or the network drops, the SDK now retries using the same idempotency key, preventing duplicate intent creation or double execution.  closes #44 