### PR TITLE
 implement Horizon operation streamer for large-transaction alerts

### DIFF
--- a/src/services/horizonOperationStreamer.service.ts
+++ b/src/services/horizonOperationStreamer.service.ts
@@ -1,0 +1,255 @@
+import * as StellarSdk from "@stellar/stellar-sdk";
+import config from "../config/config";
+import logger from "../config/logger";
+
+export const LARGE_OPERATION_ALERT_EVENT = "stellar.large_operation";
+
+export interface LargeOperationAlert {
+  operationId: string;
+  operationType: string;
+  amount: number;
+  asset: string;
+  from?: string;
+  to?: string;
+  transactionHash: string;
+  createdAt: string;
+  ledger?: number;
+  threshold: number;
+  network: string;
+}
+
+interface HorizonOperationRecord {
+  id?: string;
+  type?: string;
+  amount?: string;
+  starting_balance?: string;
+  source_amount?: string;
+  destination_amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  source_asset_type?: string;
+  source_asset_code?: string;
+  destination_asset_type?: string;
+  destination_asset_code?: string;
+  from?: string;
+  to?: string;
+  source_account?: string;
+  destination_account?: string;
+  account?: string;
+  transaction_hash?: string;
+  created_at?: string;
+  ledger?: number;
+}
+
+interface HorizonOperationStreamBuilder {
+  cursor(cursor: string): HorizonOperationStreamBuilder;
+  order(order: "asc" | "desc"): HorizonOperationStreamBuilder;
+  stream(options: {
+    onmessage: (record: HorizonOperationRecord) => void;
+    onerror: (error: unknown) => void;
+  }): () => void;
+}
+
+interface HorizonServerLike {
+  operations(): HorizonOperationStreamBuilder;
+}
+
+interface HorizonOperationStreamerOptions {
+  server?: HorizonServerLike;
+  enabled?: boolean;
+  minAmount?: number;
+  reconnectDelayMs?: number;
+}
+
+export class HorizonOperationStreamerService {
+  private readonly server: HorizonServerLike;
+  private readonly listeners = new Set<(alert: LargeOperationAlert) => void>();
+  private readonly enabled: boolean;
+  private readonly minAmount: number;
+  private readonly reconnectDelayMs: number;
+  private closeStream: (() => void) | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private running = false;
+
+  constructor(options: HorizonOperationStreamerOptions = {}) {
+    this.server =
+      options.server ??
+      ((new StellarSdk.Horizon.Server(
+        config.stellar.horizonUrl
+      ) as unknown) as HorizonServerLike);
+
+    this.enabled = options.enabled ?? process.env.STELLAR_ALERT_STREAM_ENABLED !== "false";
+    this.minAmount =
+      options.minAmount ??
+      Number.parseFloat(process.env.STELLAR_ALERT_MIN_AMOUNT || "1000");
+    this.reconnectDelayMs =
+      options.reconnectDelayMs ??
+      Number.parseInt(process.env.STELLAR_ALERT_STREAM_RECONNECT_MS || "5000", 10);
+  }
+
+  start(): void {
+    if (this.running) {
+      return;
+    }
+
+    if (!this.enabled) {
+      logger.info("Horizon operation streamer disabled by configuration");
+      return;
+    }
+
+    this.running = true;
+    this.openStream();
+  }
+
+  stop(): void {
+    this.running = false;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    if (this.closeStream) {
+      this.closeStream();
+      this.closeStream = null;
+    }
+  }
+
+  onLargeOperation(listener: (alert: LargeOperationAlert) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private openStream(): void {
+    try {
+      this.closeStream = this.server
+        .operations()
+        .cursor("now")
+        .order("asc")
+        .stream({
+          onmessage: (record) => {
+            this.handleOperation(record);
+          },
+          onerror: (error) => {
+            logger.error("Horizon operation stream error", {
+              error: error instanceof Error ? error.message : String(error),
+            });
+            this.scheduleReconnect();
+          },
+        });
+
+      logger.info("Horizon operation stream started", {
+        minAmount: this.minAmount,
+        network: config.stellar.network,
+      });
+    } catch (error) {
+      logger.error("Failed to start Horizon operation stream", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.scheduleReconnect();
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.running || this.reconnectTimer) {
+      return;
+    }
+
+    if (this.closeStream) {
+      this.closeStream();
+      this.closeStream = null;
+    }
+
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (!this.running) {
+        return;
+      }
+      this.openStream();
+    }, this.reconnectDelayMs);
+  }
+
+  private handleOperation(operation: HorizonOperationRecord): void {
+    const parsed = this.extractOperationAmount(operation);
+    if (!parsed || parsed.amount < this.minAmount) {
+      return;
+    }
+
+    const alert: LargeOperationAlert = {
+      operationId: operation.id || "unknown",
+      operationType: operation.type || "unknown",
+      amount: parsed.amount,
+      asset: parsed.asset,
+      from: operation.from || operation.source_account,
+      to: operation.to || operation.destination_account || operation.account,
+      transactionHash: operation.transaction_hash || "unknown",
+      createdAt: operation.created_at || new Date().toISOString(),
+      ledger: operation.ledger,
+      threshold: this.minAmount,
+      network: config.stellar.network,
+    };
+
+    logger.warn("Large Stellar operation detected", alert);
+    for (const listener of this.listeners) {
+      listener(alert);
+    }
+  }
+
+  private extractOperationAmount(
+    operation: HorizonOperationRecord
+  ): { amount: number; asset: string } | null {
+    if (!operation.type) {
+      return null;
+    }
+
+    if (operation.type === "payment") {
+      return {
+        amount: Number.parseFloat(operation.amount || "0"),
+        asset: this.resolveAsset(operation.asset_type, operation.asset_code),
+      };
+    }
+
+    if (operation.type === "create_account") {
+      return {
+        amount: Number.parseFloat(operation.starting_balance || "0"),
+        asset: "XLM",
+      };
+    }
+
+    if (operation.type === "path_payment_strict_send") {
+      return {
+        amount: Number.parseFloat(operation.source_amount || "0"),
+        asset: this.resolveAsset(
+          operation.source_asset_type,
+          operation.source_asset_code
+        ),
+      };
+    }
+
+    if (operation.type === "path_payment_strict_receive") {
+      return {
+        amount: Number.parseFloat(operation.destination_amount || "0"),
+        asset: this.resolveAsset(
+          operation.destination_asset_type,
+          operation.destination_asset_code
+        ),
+      };
+    }
+
+    return null;
+  }
+
+  private resolveAsset(assetType?: string, assetCode?: string): string {
+    if (assetType === "native") {
+      return "XLM";
+    }
+
+    if (assetCode) {
+      return assetCode;
+    }
+
+    return "UNKNOWN";
+  }
+}
+
+export const horizonOperationStreamerService = new HorizonOperationStreamerService();

--- a/tests/unit/horizon_operation_streamer.test.ts
+++ b/tests/unit/horizon_operation_streamer.test.ts
@@ -1,0 +1,151 @@
+import {
+  HorizonOperationStreamerService,
+  LARGE_OPERATION_ALERT_EVENT,
+} from "../../src/services/horizonOperationStreamer.service";
+
+describe("HorizonOperationStreamerService", () => {
+  let onmessageHandler: ((record: Record<string, unknown>) => void) | undefined;
+  let onerrorHandler: ((error: unknown) => void) | undefined;
+  let closeFn: ReturnType<typeof jest.fn>;
+  let streamMock: ReturnType<typeof jest.fn>;
+  let operationsBuilder: {
+    cursor: ReturnType<typeof jest.fn>;
+    order: ReturnType<typeof jest.fn>;
+    stream: ReturnType<typeof jest.fn>;
+  };
+  let server: { operations: ReturnType<typeof jest.fn> };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    closeFn = jest.fn();
+
+    streamMock = jest.fn().mockImplementation((options: {
+      onmessage: (record: Record<string, unknown>) => void;
+      onerror: (error: unknown) => void;
+    }) => {
+      onmessageHandler = options.onmessage;
+      onerrorHandler = options.onerror;
+      return closeFn;
+    });
+
+    operationsBuilder = {
+      cursor: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      stream: streamMock,
+    };
+
+    server = {
+      operations: jest.fn().mockReturnValue(operationsBuilder),
+    };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it("emits a large-operation alert for qualifying payments", () => {
+    const service = new HorizonOperationStreamerService({
+      server,
+      enabled: true,
+      minAmount: 1000,
+      reconnectDelayMs: 50,
+    });
+
+    const listener = jest.fn();
+    service.onLargeOperation(listener);
+
+    service.start();
+
+    onmessageHandler?.({
+      id: "op-1",
+      type: "payment",
+      amount: "1500.0000000",
+      asset_type: "native",
+      from: "GFROMACCOUNT",
+      to: "GTOACCOUNT",
+      transaction_hash: "txhash1",
+      created_at: "2026-02-25T12:00:00Z",
+      ledger: 12345,
+    });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const alert = listener.mock.calls[0][0];
+    expect(alert.operationId).toBe("op-1");
+    expect(alert.operationType).toBe("payment");
+    expect(alert.amount).toBe(1500);
+    expect(alert.asset).toBe("XLM");
+  });
+
+  it("does not emit alerts for operations below threshold", () => {
+    const service = new HorizonOperationStreamerService({
+      server,
+      enabled: true,
+      minAmount: 1000,
+    });
+
+    const listener = jest.fn();
+    service.onLargeOperation(listener);
+
+    service.start();
+
+    onmessageHandler?.({
+      id: "op-2",
+      type: "payment",
+      amount: "12.5",
+      asset_type: "native",
+      transaction_hash: "txhash2",
+      created_at: "2026-02-25T12:01:00Z",
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("reconnects after stream errors", () => {
+    const service = new HorizonOperationStreamerService({
+      server,
+      enabled: true,
+      minAmount: 1000,
+      reconnectDelayMs: 25,
+    });
+
+    service.start();
+    expect(streamMock).toHaveBeenCalledTimes(1);
+
+    onerrorHandler?.(new Error("stream failed"));
+
+    jest.advanceTimersByTime(25);
+
+    expect(streamMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("can unsubscribe listener and stop cleanly", () => {
+    const service = new HorizonOperationStreamerService({
+      server,
+      enabled: true,
+      minAmount: 1000,
+    });
+
+    const listener = jest.fn();
+    const unsubscribe = service.onLargeOperation(listener);
+    service.start();
+
+    unsubscribe();
+    onmessageHandler?.({
+      id: "op-3",
+      type: "payment",
+      amount: "1200",
+      asset_type: "native",
+      transaction_hash: "txhash3",
+      created_at: "2026-02-25T12:02:00Z",
+    });
+
+    expect(listener).not.toHaveBeenCalled();
+
+    service.stop();
+    expect(closeFn).toHaveBeenCalled();
+
+    // Ensure event name remains stable for downstream consumers
+    expect(LARGE_OPERATION_ALERT_EVENT).toBe("stellar.large_operation");
+  });
+});


### PR DESCRIPTION
his PR adds a backend service that listens to the Stellar Horizon operation stream and emits internal alerts when operations exceed a configurable large-transaction threshold.

What was added
1) New Horizon streamer service
Introduced HorizonOperationStreamerService to stream operations in real time and emit alert callbacks for downstream handling.
Added stable event name: stellar.large_operation.
File: @src/services/horizonOperationStreamer.service.ts#1-256
2) Large-operation detection logic
The service now detects high-value operations for:

payment (amount)
create_account (starting_balance)
path_payment_strict_send (source_amount)
path_payment_strict_receive (destination_amount)
Detection + alert payload creation:

@src/services/horizonOperationStreamer.service.ts#172-240
3) Startup / shutdown wiring
Streamer starts when backend boots and stops during graceful shutdown.
Added listener hook to log emitted large-operation alerts.
File: @src/index.ts#17-38
4) Test coverage
Added unit tests for:

emits alert for qualifying payments
ignores below-threshold operations
reconnects after stream errors
unsubscribe + clean stop behavior
File: @tests/unit/horizon_operation_streamer.test.ts#1-152
closes #59 