### PR TITLE
 implement persistent MemoryStore for multi-turn agent conversations

### DIFF
--- a/src/Agents/memory/memory.ts
+++ b/src/Agents/memory/memory.ts
@@ -1,39 +1,109 @@
-type MemoryItem = {
-  agentId: string;
-  context: string[];
-};
+import logger from "../../config/logger";
+
+declare const process: { cwd: () => string };
+declare function require(moduleName: string): any;
+
+const fs = require("fs");
+const path = require("path");
+
+type PersistedMemory = Record<string, string[]>;
 
 export class MemoryStore {
-  private memories: MemoryItem[] = [];
+  private memories = new Map<string, string[]>();
   private maxContextPerAgent: number;
+  private storageFilePath: string;
 
-  constructor(maxContextPerAgent = 10) {
+  constructor(
+    maxContextPerAgent = 10,
+    storageFilePath = path.resolve(process.cwd(), "data", "agent-memory.json")
+  ) {
     this.maxContextPerAgent = maxContextPerAgent;
+    this.storageFilePath = storageFilePath;
+    this.loadFromDisk();
   }
-  
-  add(agentId: string, entry: string) {
-    let memory = this.memories.find((m) => m.agentId === agentId);
-    if (!memory) {
-      memory = { agentId, context: [] };
-      this.memories.push(memory);
-    }
-    memory.context.push(entry);
-    if (memory.context.length > this.maxContextPerAgent) {
-      memory.context = memory.context.slice(-this.maxContextPerAgent);
-    }
+
+  add(agentId: string, entry: string): void {
+    const existing = this.memories.get(agentId) ?? [];
+    const updated = [...existing, entry].slice(-this.maxContextPerAgent);
+    this.memories.set(agentId, updated);
+    this.persistToDisk();
   }
 
   get(agentId: string): string[] {
-    const memory = this.memories.find((m) => m.agentId === agentId);
-    return memory ? memory.context : [];
+    const memory = this.memories.get(agentId);
+    return memory ? [...memory] : [];
   }
 
-  clear(agentId: string) {
-    this.memories = this.memories.filter((m) => m.agentId !== agentId);
+  clear(agentId: string): void {
+    const removed = this.memories.delete(agentId);
+    if (removed) {
+      this.persistToDisk();
+    }
   }
 
-  clearAll() {
-    this.memories = [];
+  clearAll(): void {
+    if (this.memories.size === 0) {
+      return;
+    }
+
+    this.memories.clear();
+    this.persistToDisk();
+  }
+
+  private loadFromDisk(): void {
+    try {
+      if (!fs.existsSync(this.storageFilePath)) {
+        return;
+      }
+
+      const raw = fs.readFileSync(this.storageFilePath, "utf-8");
+      if (!raw.trim()) {
+        return;
+      }
+
+      const parsed = JSON.parse(raw) as PersistedMemory;
+      for (const agentId in parsed) {
+        if (!Object.prototype.hasOwnProperty.call(parsed, agentId)) {
+          continue;
+        }
+
+        const context = parsed[agentId];
+        if (!Array.isArray(context)) {
+          continue;
+        }
+
+        const sanitized = context
+          .filter((entry): entry is string => typeof entry === "string")
+          .slice(-this.maxContextPerAgent);
+        if (sanitized.length > 0) {
+          this.memories.set(agentId, sanitized);
+        }
+      }
+    } catch (error) {
+      logger.error("Failed to load agent memory store from disk", {
+        error,
+        storageFilePath: this.storageFilePath,
+      });
+    }
+  }
+
+  private persistToDisk(): void {
+    try {
+      const directory = path.dirname(this.storageFilePath);
+      fs.mkdirSync(directory, { recursive: true });
+
+      const data: PersistedMemory = {};
+      for (const [agentId, context] of this.memories.entries()) {
+        data[agentId] = context;
+      }
+
+      fs.writeFileSync(this.storageFilePath, JSON.stringify(data, null, 2), "utf-8");
+    } catch (error) {
+      logger.error("Failed to persist agent memory store to disk", {
+        error,
+        storageFilePath: this.storageFilePath,
+      });
+    }
   }
 }
 

--- a/tests/unit/memory_store.test.ts
+++ b/tests/unit/memory_store.test.ts
@@ -1,0 +1,72 @@
+declare function require(moduleName: string): any;
+declare const process: { cwd: () => string };
+
+import { MemoryStore } from "../../src/Agents/memory/memory";
+
+const fs = require("fs");
+const path = require("path");
+
+describe("MemoryStore", () => {
+  let storageDirectory: string;
+  let storageFilePath: string;
+
+  beforeEach(() => {
+    storageDirectory = path.resolve(
+      process.cwd(),
+      "tmp",
+      `memory-store-tests-${Date.now()}-${Math.floor(Math.random() * 10000)}`
+    );
+    storageFilePath = path.join(storageDirectory, "agent-memory.json");
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(storageDirectory)) {
+      fs.rmSync(storageDirectory, { recursive: true, force: true });
+    }
+  });
+
+  it("persists memory entries and reloads them", () => {
+    const store = new MemoryStore(10, storageFilePath);
+
+    store.add("user-1", "User: hello");
+    store.add("user-1", "LLM: hi there");
+
+    const reloadedStore = new MemoryStore(10, storageFilePath);
+
+    expect(reloadedStore.get("user-1")).toEqual([
+      "User: hello",
+      "LLM: hi there",
+    ]);
+  });
+
+  it("enforces max context per agent across reloads", () => {
+    const store = new MemoryStore(2, storageFilePath);
+
+    store.add("user-1", "entry-1");
+    store.add("user-1", "entry-2");
+    store.add("user-1", "entry-3");
+
+    expect(store.get("user-1")).toEqual(["entry-2", "entry-3"]);
+
+    const reloadedStore = new MemoryStore(2, storageFilePath);
+    expect(reloadedStore.get("user-1")).toEqual(["entry-2", "entry-3"]);
+  });
+
+  it("persists clear and clearAll operations", () => {
+    const store = new MemoryStore(10, storageFilePath);
+
+    store.add("user-1", "entry-1");
+    store.add("user-2", "entry-2");
+    store.clear("user-1");
+
+    let reloadedStore = new MemoryStore(10, storageFilePath);
+    expect(reloadedStore.get("user-1")).toEqual([]);
+    expect(reloadedStore.get("user-2")).toEqual(["entry-2"]);
+
+    reloadedStore.clearAll();
+    reloadedStore = new MemoryStore(10, storageFilePath);
+
+    expect(reloadedStore.get("user-1")).toEqual([]);
+    expect(reloadedStore.get("user-2")).toEqual([]);
+  });
+});


### PR DESCRIPTION
Summary
This PR implements a persistent MemoryStore in src/Agents/memory so agent conversation context survives process restarts and supports true multi-turn behavior. closes #48 