### PR TITLE
 introduce modular external KYC provider interface and pluggable prov…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=
 REDIS_DB=0
+
+# KYC Provider Configuration
+# Available values depend on registered provider adapters (default: mock)
+KYC_PROVIDER=mock
+
 # JWT Configuration
 JWT_ACCESS_SECRET=your_jwt_access_secret_min_32_chars
 JWT_REFRESH_SECRET=your_jwt_refresh_secret_min_32_chars

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -64,6 +64,10 @@ export default {
     port: parseInt(process.env.REDIS_PORT || "6379"),
     password: process.env.REDIS_PASSWORD || undefined,
     db: parseInt(process.env.REDIS_DB || "0"),
+  },
+  kyc: {
+    defaultProvider: process.env.KYC_PROVIDER || "mock",
+  },
   jwt: {
     secret: process.env.JWT_SECRET || "secret-token",
     resetExpiry: process.env.JWT_RESET_EXPIRY || "1h",

--- a/src/services/kyc/KycProviderFactory.ts
+++ b/src/services/kyc/KycProviderFactory.ts
@@ -1,0 +1,35 @@
+import { KycProvider } from "./types";
+
+export class KycProviderFactory {
+  private providers = new Map<string, KycProvider>();
+  private defaultProviderName: string;
+
+  constructor(defaultProviderName: string) {
+    this.defaultProviderName = defaultProviderName;
+  }
+
+  register(provider: KycProvider): void {
+    this.providers.set(provider.name, provider);
+  }
+
+  setDefaultProvider(providerName: string): void {
+    this.defaultProviderName = providerName;
+  }
+
+  getProvider(providerName?: string): KycProvider {
+    const selectedProviderName = providerName || this.defaultProviderName;
+    const provider = this.providers.get(selectedProviderName);
+
+    if (!provider) {
+      throw new Error(
+        `KYC provider '${selectedProviderName}' is not registered`
+      );
+    }
+
+    return provider;
+  }
+
+  getRegisteredProviders(): string[] {
+    return Array.from(this.providers.keys());
+  }
+}

--- a/src/services/kyc/KycService.ts
+++ b/src/services/kyc/KycService.ts
@@ -1,0 +1,48 @@
+import config from "../../config/config";
+import logger from "../../config/logger";
+import { KycProviderFactory } from "./KycProviderFactory";
+import { MockKycProvider } from "./providers/mockKycProvider";
+import { KycVerificationRequest, KycVerificationResult } from "./types";
+
+export class KycService {
+  constructor(private readonly providerFactory: KycProviderFactory) {}
+
+  async submitVerification(
+    request: KycVerificationRequest,
+    providerName?: string
+  ): Promise<KycVerificationResult> {
+    const provider = this.providerFactory.getProvider(providerName);
+    const result = await provider.createVerification(request);
+
+    logger.info("KYC verification submitted", {
+      provider: provider.name,
+      userId: request.person.userId,
+      providerReferenceId: result.providerReferenceId,
+      status: result.status,
+    });
+
+    return result;
+  }
+
+  async getVerificationStatus(
+    providerReferenceId: string,
+    providerName?: string
+  ): Promise<KycVerificationResult | null> {
+    const provider = this.providerFactory.getProvider(providerName);
+    return provider.getVerificationStatus(providerReferenceId);
+  }
+
+  async healthCheck(providerName?: string): Promise<boolean> {
+    const provider = this.providerFactory.getProvider(providerName);
+    return provider.healthCheck();
+  }
+
+  getRegisteredProviders(): string[] {
+    return this.providerFactory.getRegisteredProviders();
+  }
+}
+
+const kycProviderFactory = new KycProviderFactory(config.kyc.defaultProvider);
+kycProviderFactory.register(new MockKycProvider());
+
+export const kycService = new KycService(kycProviderFactory);

--- a/src/services/kyc/index.ts
+++ b/src/services/kyc/index.ts
@@ -1,0 +1,4 @@
+export * from "./types";
+export * from "./KycProviderFactory";
+export * from "./KycService";
+export * from "./providers/mockKycProvider";

--- a/src/services/kyc/providers/mockKycProvider.ts
+++ b/src/services/kyc/providers/mockKycProvider.ts
@@ -1,0 +1,46 @@
+import {
+  KycProvider,
+  KycVerificationRequest,
+  KycVerificationResult,
+} from "../types";
+
+export class MockKycProvider implements KycProvider {
+  readonly name = "mock";
+  private records = new Map<string, KycVerificationResult>();
+
+  async createVerification(
+    request: KycVerificationRequest
+  ): Promise<KycVerificationResult> {
+    const providerReferenceId =
+      request.referenceId ||
+      `kyc_${request.person.userId}_${Date.now().toString(36)}`;
+
+    const fullName = request.person.fullName.toLowerCase();
+    const status = fullName.includes("reject") ? "rejected" : "pending";
+
+    const result: KycVerificationResult = {
+      provider: this.name,
+      providerReferenceId,
+      status,
+      reason:
+        status === "rejected"
+          ? "Mock provider triggered rejection based on profile data"
+          : undefined,
+      reviewedAt: status === "rejected" ? new Date().toISOString() : undefined,
+      metadata: request.metadata,
+    };
+
+    this.records.set(providerReferenceId, result);
+    return result;
+  }
+
+  async getVerificationStatus(
+    providerReferenceId: string
+  ): Promise<KycVerificationResult | null> {
+    return this.records.get(providerReferenceId) || null;
+  }
+
+  async healthCheck(): Promise<boolean> {
+    return true;
+  }
+}

--- a/src/services/kyc/types.ts
+++ b/src/services/kyc/types.ts
@@ -1,0 +1,63 @@
+export type KycVerificationStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "manual_review";
+
+export type KycDocumentType =
+  | "passport"
+  | "national_id"
+  | "drivers_license"
+  | "proof_of_address"
+  | "selfie";
+
+export interface KycDocumentInput {
+  type: KycDocumentType;
+  documentId?: string;
+  fileUrl?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface KycPersonInput {
+  userId: string;
+  fullName: string;
+  dateOfBirth?: string;
+  email?: string;
+  phoneNumber?: string;
+  countryCode?: string;
+  addressLine1?: string;
+  addressLine2?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+}
+
+export interface KycVerificationRequest {
+  person: KycPersonInput;
+  documents: KycDocumentInput[];
+  referenceId?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface KycVerificationResult {
+  provider: string;
+  providerReferenceId: string;
+  status: KycVerificationStatus;
+  reason?: string;
+  reviewedAt?: string;
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface KycProvider {
+  readonly name: string;
+
+  createVerification(
+    request: KycVerificationRequest
+  ): Promise<KycVerificationResult>;
+
+  getVerificationStatus(
+    providerReferenceId: string
+  ): Promise<KycVerificationResult | null>;
+
+  healthCheck(): Promise<boolean>;
+}

--- a/tests/unit/kyc_service.test.ts
+++ b/tests/unit/kyc_service.test.ts
@@ -1,0 +1,137 @@
+import { KycProviderFactory } from "../../src/services/kyc/KycProviderFactory";
+import { KycService } from "../../src/services/kyc/KycService";
+import { MockKycProvider } from "../../src/services/kyc/providers/mockKycProvider";
+import {
+  KycProvider,
+  KycVerificationRequest,
+  KycVerificationResult,
+} from "../../src/services/kyc/types";
+
+describe("KycProviderFactory", () => {
+  it("returns default provider when no provider name is specified", () => {
+    const factory = new KycProviderFactory("mock");
+    const provider = new MockKycProvider();
+
+    factory.register(provider);
+
+    expect(factory.getProvider()).toBe(provider);
+  });
+
+  it("throws when provider is not registered", () => {
+    const factory = new KycProviderFactory("unknown");
+
+    expect(() => factory.getProvider()).toThrow(
+      "KYC provider 'unknown' is not registered"
+    );
+  });
+
+  it("can switch default provider", () => {
+    const factory = new KycProviderFactory("mock");
+
+    const mock = new MockKycProvider();
+    const stub: KycProvider = {
+      name: "stub",
+      createVerification: jest.fn(),
+      getVerificationStatus: jest.fn(),
+      healthCheck: jest.fn(),
+    };
+
+    factory.register(mock);
+    factory.register(stub);
+
+    factory.setDefaultProvider("stub");
+
+    expect(factory.getProvider()).toBe(stub);
+    expect(factory.getRegisteredProviders().sort()).toEqual(["mock", "stub"]);
+  });
+});
+
+describe("KycService", () => {
+  const baseRequest: KycVerificationRequest = {
+    person: {
+      userId: "user-123",
+      fullName: "Jane Doe",
+      email: "jane@example.com",
+      countryCode: "US",
+    },
+    documents: [
+      {
+        type: "passport",
+        documentId: "passport-1",
+      },
+    ],
+    metadata: {
+      flow: "onboarding",
+    },
+  };
+
+  it("submits verification through selected provider", async () => {
+    const factory = new KycProviderFactory("mock");
+    factory.register(new MockKycProvider());
+
+    const service = new KycService(factory);
+    const result = await service.submitVerification(baseRequest);
+
+    expect(result.provider).toBe("mock");
+    expect(result.providerReferenceId).toContain("kyc_user-123_");
+    expect(result.status).toBe("pending");
+  });
+
+  it("retrieves verification status by provider reference id", async () => {
+    const factory = new KycProviderFactory("mock");
+    factory.register(new MockKycProvider());
+
+    const service = new KycService(factory);
+    const created = await service.submitVerification(baseRequest);
+    const status = await service.getVerificationStatus(created.providerReferenceId);
+
+    expect(status).not.toBeNull();
+    expect(status?.providerReferenceId).toBe(created.providerReferenceId);
+    expect(status?.status).toBe("pending");
+  });
+
+  it("supports provider-driven rejection outcomes", async () => {
+    const factory = new KycProviderFactory("mock");
+    factory.register(new MockKycProvider());
+
+    const service = new KycService(factory);
+    const rejectedRequest: KycVerificationRequest = {
+      ...baseRequest,
+      person: {
+        ...baseRequest.person,
+        fullName: "Reject Candidate",
+      },
+    };
+
+    const result = await service.submitVerification(rejectedRequest);
+
+    expect(result.status).toBe("rejected");
+    expect(result.reason).toContain("Mock provider");
+  });
+
+  it("delegates health checks to provider", async () => {
+    const healthyProvider: KycProvider = {
+      name: "healthy",
+      createVerification: jest
+        .fn<Promise<KycVerificationResult>, [KycVerificationRequest]>()
+        .mockResolvedValue({
+          provider: "healthy",
+          providerReferenceId: "ref-1",
+          status: "approved",
+        }),
+      getVerificationStatus: jest
+        .fn<Promise<KycVerificationResult | null>, [string]>()
+        .mockResolvedValue(null),
+      healthCheck: jest.fn<Promise<boolean>, []>().mockResolvedValue(true),
+    };
+
+    const factory = new KycProviderFactory("healthy");
+    factory.register(healthyProvider);
+
+    const service = new KycService(factory);
+    const result = await service.healthCheck();
+
+    expect(result).toBe(true);
+    expect(healthyProvider.healthCheck).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
closes #77 
Summary
Implements issue #77 by adding a modular KYC integration layer that allows Chenpilot to support multiple external identity verification providers behind a shared interface.
This sets the backend up for future regulatory/compliance integrations without coupling business logic to a single vendor.

What Changed
1) Added provider interface and KYC domain types
Introduced a shared contract for all KYC providers and standardized request/response models:

KycProvider interface:
createVerification
getVerificationStatus
healthCheck
Core types:
verification status
person/document payloads
verification request/result models
File: @src/services/kyc/types.ts#1-66

2) Added provider factory/registry
Implemented KycProviderFactory to:

register providers by name
resolve explicit provider or fallback to default provider
fail fast for unknown provider configuration
File: @src/services/kyc/KycProviderFactory.ts#1-36

3) Added default/mock provider adapter
Implemented MockKycProvider as an initial adapter conforming to KycProvider, enabling:

deterministic local/testing behavior
status retrieval by provider reference id
easy replacement with real third-party providers later
File: @src/services/kyc/providers/mockKycProvider.ts#1-47

4) Added KYC service orchestration
Implemented KycService to centralize provider selection and delegate operations through the provider contract.
Also exports a default singleton wired to configured default provider.

File: @src/services/kyc/KycService.ts#1-49
Barrel export: @src/services/kyc/index.ts#1-4

5) Added configuration for provider selection
Added config/env support for default KYC provider selection:

config.kyc.defaultProvider
.env key: KYC_PROVIDER=mock
Config file: @src/config/config.ts#68-74
Env example: @.env.example#29-35

6) Added unit tests
Created focused tests validating:

default provider resolution
unknown provider error handling
default provider switching
submit + status retrieval flow
provider-driven rejection behavior
health-check delegation
File: @tests/unit/kyc_service.test.ts#1-138