### PR TITLE
feat: implement bot command performance profiling metrics 

### DIFF
--- a/packages/bot/src/adapters/discord.ts
+++ b/packages/bot/src/adapters/discord.ts
@@ -15,10 +15,12 @@ import {
 } from "@chen-pilot/sdk-core";
 import { searchFeatures, formatHelpMessage } from "../services/helpProvider";
 import { AssetVerificationService } from '../assetVerification';
+import { withPerformanceProfiling, extractCommandName } from '../performanceProfiler';
 
 const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:3000";
 const DASHBOARD_URL = process.env.DASHBOARD_URL || `${BACKEND_URL}/dashboard`;
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+const DEBOUNCE_MS = 1000; // 1 second debounce between commands
 
 // Commands that involve personal account data and must only be used in DMs
 const DM_ONLY_COMMANDS = ['!balance', '!sponsor'];
@@ -84,181 +86,202 @@ export class DiscordAdapter {
       this.startStatusUpdates();
     });
 
-    this.client.on("messageCreate", async (message: Message) => {
-      if (message.author.bot) return;
+    this.client.on("messageCreate", withPerformanceProfiling(
+      'messageCreate',
+      'discord',
+      'system',
+      async (message: Message) => {
+        if (message.author.bot) return;
 
-      const userId = message.author.id;
+        const userId = message.author.id;
+        const commandName = extractCommandName(message.content, 'discord');
 
-      // #145: Anti-flood check for all commands
-      if (this.isFlooding(userId)) {
-        await message.reply("⏳ Please wait a moment before sending another command.");
-        return;
-      }
-
-      if (message.content === "!start") {
-        await message.reply(
-          "Welcome to Chen Pilot! I am your AI-powered Stellar DeFi assistant. Type !help to see what I can do!"
-        );
-      }
-
-      if (message.content.startsWith("!help")) {
-        const query = message.content.replace("!help", "").trim();
-        const results = searchFeatures(query);
-        const isSearch = query.length > 0;
-        await message.reply(formatHelpMessage(results, isSearch, "markdown"));
-      }
-
-      if (message.content === "!thread") {
-        if (message.channel.type === ChannelType.GuildText) {
-          try {
-            const thread = await message.startThread({
-              name: `Chen Pilot Session - ${message.author.username}`,
-              autoArchiveDuration: 60,
-            });
-            await thread.send(
-              `👋 Hello ${message.author.username}! I've started this thread to keep our conversation organized. How can I help you with Stellar DeFi today?`
-            );
-          } catch (error) {
-            console.error("Error creating thread:", error);
-            await message.reply(
-              "❌ I couldn't start a thread. Please make sure I have the 'Create Public Threads' permission."
-            );
-          }
-        } else if (message.channel.isThread()) {
-          await message.reply(
-            "🧵 We are already in a thread! I'm ready to assist you here."
-          );
-        } else {
-          await message.reply(
-            "❌ Threads can only be started in text channels."
-          );
+        // #145: Anti-flood check for all commands
+        if (this.isFlooding(userId)) {
+          await message.reply("⏳ Please wait a moment before sending another command.");
+          return;
         }
-      }
 
-      if (message.content === "!sponsor") {
-        await message.reply("⏳ Requesting account sponsorship...");
+        // Wrap each command handler with performance profiling
+        if (message.content === "!start") {
+          await withPerformanceProfiling('!start', 'discord', userId, async () => {
+            await message.reply(
+              "Welcome to Chen Pilot! I am your AI-powered Stellar DeFi assistant. Type !help to see what I can do!"
+            );
+          })();
+        }
 
-        try {
-          const response = await fetch(
-            `${BACKEND_URL}/api/account/${userId}/sponsor`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
+        if (message.content.startsWith("!help")) {
+          await withPerformanceProfiling(commandName, 'discord', userId, async () => {
+            const query = message.content.replace("!help", "").trim();
+            const results = searchFeatures(query);
+            const isSearch = query.length > 0;
+            await message.reply(formatHelpMessage(results, isSearch, "markdown"));
+          })();
+        }
+
+        if (message.content === "!thread") {
+          await withPerformanceProfiling('!thread', 'discord', userId, async () => {
+            if (message.channel.type === ChannelType.GuildText) {
+              try {
+                const thread = await message.startThread({
+                  name: `Chen Pilot Session - ${message.author.username}`,
+                  autoArchiveDuration: 60,
+                });
+                await thread.send(
+                  `👋 Hello ${message.author.username}! I've started this thread to keep our conversation organized. How can I help you with Stellar DeFi today?`
+                );
+              } catch (error) {
+                console.error("Error creating thread:", error);
+                await message.reply(
+                  "❌ I couldn't start a thread. Please make sure I have the 'Create Public Threads' permission."
+                );
+              }
+            } else if (message.channel.isThread()) {
+              await message.reply(
+                "🧵 We are already in a thread! I'm ready to assist you here."
+              );
+            } else {
+              await message.reply(
+                "❌ Threads can only be started in text channels."
+              );
             }
-          );
-          const data = (await response.json()) as {
-            success: boolean;
-            message: string;
-            address?: string;
-          };
+          })();
+        }
 
-          if (data.success) {
+        if (message.content === "!sponsor") {
+          await withPerformanceProfiling('!sponsor', 'discord', userId, async () => {
+            await message.reply("⏳ Requesting account sponsorship...");
+
+            try {
+              const response = await fetch(
+                `${BACKEND_URL}/api/account/${userId}/sponsor`,
+                {
+                  method: "POST",
+                  headers: { "Content-Type": "application/json" },
+                }
+              );
+              const data = (await response.json()) as {
+                success: boolean;
+                message: string;
+                address?: string;
+              };
+
+              if (data.success) {
+                await message.reply(
+                  `✅ Account sponsored successfully!\n📬 Address: \`${data.address}\``
+                );
+                await this.logAuditAction({
+                  action: 'SPONSOR_ACCOUNT',
+                  triggeredBy: userId,
+                  details: `Address: ${data.address}`,
+                  success: true,
+                  timestamp: new Date().toISOString(),
+                });
+              } else {
+                await message.reply(`❌ Sponsorship failed: ${data.message}`);
+                await this.logAuditAction({
+                  action: 'SPONSOR_ACCOUNT',
+                  triggeredBy: userId,
+                  details: `Failed: ${data.message}`,
+                  success: false,
+                  timestamp: new Date().toISOString(),
+                });
+              }
+            } catch (error) {
+              console.error("Sponsor command error:", error);
+              await message.reply(
+                "❌ Could not reach the sponsorship service. Please try again later."
+              );
+            }
+          })();
+        }
+
+        if (message.content.startsWith("!trustline")) {
+          await withPerformanceProfiling(commandName, 'discord', userId, async () => {
+            const args = message.content.split(" ").slice(1);
+            if (args.length < 1) {
+              return message.reply(
+                "Usage: !trustline <assetCode> [issuerDomain|issuerAddress]\nExample: !trustline USDC circle.com"
+              );
+            }
+
+            const assetCode = args[0];
+            const assetIssuer = args[1];
+
+            if (!assetIssuer) {
+              return message.reply(
+                `Please provide an issuer domain or address for ${assetCode}.`
+              );
+            }
+
+            try {
+              await message.reply(
+                `🔍 Looking up asset ${assetCode} from ${assetIssuer}...`
+              );
+              const op = await createTrustlineOperation(assetCode, assetIssuer);
+
+              let response = `✅ Found asset ${assetCode}!\n\n`;
+              response += `To add this trustline, you can use the following details in your wallet:\n`;
+              response += `**Asset:** ${assetCode}\n`;
+              response += `**Issuer:** \`${(op as any).asset.issuer}\`\n\n`;
+              response += `*Note: In a future update, I will provide a direct signing link.*`;
+
+              await message.reply(response);
+              await this.logAuditAction({
+                action: 'TRUSTLINE_LOOKUP',
+                triggeredBy: message.author.id,
+                details: `Asset: ${assetCode}, Issuer: ${assetIssuer}`,
+                success: true,
+                timestamp: new Date().toISOString(),
+              });
+            } catch (error) {
+              await message.reply(
+                `❌ Error: ${error instanceof Error ? error.message : String(error)}`
+              );
+            }
+          })();
+        }
+
+        // #146: Dashboard command
+        if (message.content === '!dashboard') {
+          await withPerformanceProfiling('!dashboard', 'discord', userId, async () => {
             await message.reply(
-              `✅ Account sponsored successfully!\n📬 Address: \`${data.address}\``
+              `📊 **Chen Pilot Dashboard**\n\nAccess your admin dashboard here:\n🔗 ${DASHBOARD_URL}\n\n*Note: You must be logged in to view the dashboard.*`
             );
-            await this.logAuditAction({
-              action: 'SPONSOR_ACCOUNT',
-              triggeredBy: userId,
-              details: `Address: ${data.address}`,
-              success: true,
-              timestamp: new Date().toISOString(),
-            });
-          } else {
-            await message.reply(`❌ Sponsorship failed: ${data.message}`);
-            await this.logAuditAction({
-              action: 'SPONSOR_ACCOUNT',
-              triggeredBy: userId,
-              details: `Failed: ${data.message}`,
-              success: false,
-              timestamp: new Date().toISOString(),
-            });
-          }
-        } catch (error) {
-          console.error("Sponsor command error:", error);
-          await message.reply(
-            "❌ Could not reach the sponsorship service. Please try again later."
-          );
+          })();
+        }
+
+        // #148: /validate command for Stellar asset verification
+        if (message.content.startsWith('!validate')) {
+          await withPerformanceProfiling(commandName, 'discord', userId, async () => {
+            const args = message.content.split(' ').slice(1);
+            if (args.length < 2) {
+              return message.reply('Usage: !validate <assetCode> <issuerAddress>\nExample: !validate USDC GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5');
+            }
+
+            const [assetCode, issuerAddress] = args;
+            await message.reply(`🔍 Verifying asset **${assetCode}** from issuer \`${issuerAddress.slice(0, 8)}...\``);
+
+            try {
+              const result = await this.verificationService.verifyAsset(assetCode, issuerAddress);
+              const statusEmoji = result.status === 'VERIFIED' ? '✅' : result.status === 'MALICIOUS' ? '🚨' : '⚠️';
+
+              let reply = `${statusEmoji} **Asset Verification: ${result.status}**\n\n`;
+              reply += `**Asset:** ${assetCode}\n`;
+              reply += `**Issuer:** \`${issuerAddress}\`\n`;
+              if (result.domain) reply += `**Domain:** ${result.domain}\n`;
+              if (result.details) reply += `**Details:** ${result.details}\n`;
+              reply += `\n**Safe to use:** ${result.isSafe ? 'Yes ✅' : 'No ❌'}`;
+
+              await message.reply(reply);
+            } catch (error) {
+              await message.reply(`❌ Verification error: ${error instanceof Error ? error.message : String(error)}`);
+            }
+          })();
         }
       }
-
-      if (message.content.startsWith("!trustline")) {
-        const args = message.content.split(" ").slice(1);
-        if (args.length < 1) {
-          return message.reply(
-            "Usage: !trustline <assetCode> [issuerDomain|issuerAddress]\nExample: !trustline USDC circle.com"
-          );
-        }
-
-        const assetCode = args[0];
-        const assetIssuer = args[1];
-
-        if (!assetIssuer) {
-          return message.reply(
-            `Please provide an issuer domain or address for ${assetCode}.`
-          );
-        }
-
-        try {
-          await message.reply(
-            `🔍 Looking up asset ${assetCode} from ${assetIssuer}...`
-          );
-          const op = await createTrustlineOperation(assetCode, assetIssuer);
-
-          let response = `✅ Found asset ${assetCode}!\n\n`;
-          response += `To add this trustline, you can use the following details in your wallet:\n`;
-          response += `**Asset:** ${assetCode}\n`;
-          response += `**Issuer:** \`${(op as any).asset.issuer}\`\n\n`;
-          response += `*Note: In a future update, I will provide a direct signing link.*`;
-
-          await message.reply(response);
-          await this.logAuditAction({
-            action: 'TRUSTLINE_LOOKUP',
-            triggeredBy: message.author.id,
-            details: `Asset: ${assetCode}, Issuer: ${assetIssuer}`,
-            success: true,
-            timestamp: new Date().toISOString(),
-          });
-        } catch (error) {
-          await message.reply(
-            `❌ Error: ${error instanceof Error ? error.message : String(error)}`
-          );
-        }
-      }
-
-      // #146: Dashboard command
-      if (message.content === '!dashboard') {
-        await message.reply(
-          `📊 **Chen Pilot Dashboard**\n\nAccess your admin dashboard here:\n🔗 ${DASHBOARD_URL}\n\n*Note: You must be logged in to view the dashboard.*`
-        );
-      }
-
-      // #148: /validate command for Stellar asset verification
-      if (message.content.startsWith('!validate')) {
-        const args = message.content.split(' ').slice(1);
-        if (args.length < 2) {
-          return message.reply('Usage: !validate <assetCode> <issuerAddress>\nExample: !validate USDC GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5');
-        }
-
-        const [assetCode, issuerAddress] = args;
-        await message.reply(`🔍 Verifying asset **${assetCode}** from issuer \`${issuerAddress.slice(0, 8)}...\``);
-
-        try {
-          const result = await this.verificationService.verifyAsset(assetCode, issuerAddress);
-          const statusEmoji = result.status === 'VERIFIED' ? '✅' : result.status === 'MALICIOUS' ? '🚨' : '⚠️';
-
-          let reply = `${statusEmoji} **Asset Verification: ${result.status}**\n\n`;
-          reply += `**Asset:** ${assetCode}\n`;
-          reply += `**Issuer:** \`${issuerAddress}\`\n`;
-          if (result.domain) reply += `**Domain:** ${result.domain}\n`;
-          if (result.details) reply += `**Details:** ${result.details}\n`;
-          reply += `\n**Safe to use:** ${result.isSafe ? 'Yes ✅' : 'No ❌'}`;
-
-          await message.reply(reply);
-        } catch (error) {
-          await message.reply(`❌ Verification error: ${error instanceof Error ? error.message : String(error)}`);
-        }
-      }
-    });
+    ));
 
     await this.client.login(token);
     console.log("✅ Discord bot initialized.");

--- a/packages/bot/src/adapters/telegram.ts
+++ b/packages/bot/src/adapters/telegram.ts
@@ -3,9 +3,11 @@ import { TransactionNotificationData } from "../types";
 import { createTrustlineOperation } from "@chen-pilot/sdk-core";
 import { searchFeatures, formatHelpMessage } from "../services/helpProvider";
 import { AssetVerificationService } from '../assetVerification';
+import { withPerformanceProfiling, extractCommandName } from '../performanceProfiler';
 
 const DASHBOARD_URL = process.env.DASHBOARD_URL || `${process.env.API_BASE_URL || 'http://localhost:2333'}/dashboard`;
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+const DEBOUNCE_MS = 1000; // 1 second debounce between commands
 
 // Commands that involve personal account data and must only be used in DMs
 const DM_ONLY_COMMANDS = ['/balance'];
@@ -58,83 +60,100 @@ export class TelegramAdapter {
       return next();
     });
 
-    this.bot.start((ctx: any) => ctx.reply('Welcome to Chen Pilot! I am your AI-powered Stellar DeFi assistant.'));
-    this.bot.help((ctx: any) => ctx.reply('Commands: /start, /balance, /swap, /trustline, /dashboard, /validate'));
+    this.bot.start(async (ctx: any) => {
+      const userId = String(ctx.from?.id || 'unknown');
+      await withPerformanceProfiling('/start', 'telegram', userId, () => ctx.reply('Welcome to Chen Pilot! I am your AI-powered Stellar DeFi assistant.'))();
+    });
+    this.bot.help(async (ctx: any) => {
+      const userId = String(ctx.from?.id || 'unknown');
+      await withPerformanceProfiling('/help', 'telegram', userId, () => ctx.reply('Commands: /start, /balance, /swap, /trustline, /dashboard, /validate'))();
+    });
 
     this.bot.command('trustline', async (ctx: any) => {
-      const args = ctx.message.text.split(' ').slice(1);
-      if (args.length < 1) {
-        return ctx.reply(
-          "Usage: /trustline <assetCode> [issuerDomain|issuerAddress]\nExample: /trustline USDC circle.com"
-        );
-      }
+      const userId = String(ctx.from?.id || 'unknown');
+      const commandName = extractCommandName(ctx.message.text, 'telegram');
+      await withPerformanceProfiling(commandName, 'telegram', userId, async () => {
+        const args = ctx.message.text.split(' ').slice(1);
+        if (args.length < 1) {
+          return ctx.reply(
+            "Usage: /trustline <assetCode> [issuerDomain|issuerAddress]\nExample: /trustline USDC circle.com"
+          );
+        }
 
-      const assetCode = args[0];
-      const assetIssuer = args[1];
+        const assetCode = args[0];
+        const assetIssuer = args[1];
 
-      if (!assetIssuer) {
-        return ctx.reply(
-          `Please provide an issuer domain or address for ${assetCode}.`
-        );
-      }
+        if (!assetIssuer) {
+          return ctx.reply(
+            `Please provide an issuer domain or address for ${assetCode}.`
+          );
+        }
 
-      try {
-        await ctx.reply(
-          `🔍 Looking up asset ${assetCode} from ${assetIssuer}...`
-        );
-        const op = await createTrustlineOperation(assetCode, assetIssuer);
+        try {
+          await ctx.reply(
+            `🔍 Looking up asset ${assetCode} from ${assetIssuer}...`
+          );
+          const op = await createTrustlineOperation(assetCode, assetIssuer);
 
-        // In a real scenario, we would generate a signing link (e.g., Albedo or Stellar Laboratory)
-        // For now, we'll return the operation details
-        let message = `✅ Found asset ${assetCode}!\n\n`;
-        message += `To add this trustline, you can use the following details in your wallet:\n`;
-        message += `<b>Asset:</b> ${assetCode}\n`;
-        message += `<b>Issuer:</b> <code>${(op as any).asset.issuer}</code>\n\n`;
-        message += `<i>Note: In a future update, I will provide a direct signing link.</i>`;
+          // In a real scenario, we would generate a signing link (e.g., Albedo or Stellar Laboratory)
+          // For now, we'll return the operation details
+          let message = `✅ Found asset ${assetCode}!\n\n`;
+          message += `To add this trustline, you can use the following details in your wallet:\n`;
+          message += `<b>Asset:</b> ${assetCode}\n`;
+          message += `<b>Issuer:</b> <code>${(op as any).asset.issuer}</code>\n\n`;
+          message += `<i>Note: In a future update, I will provide a direct signing link.</i>`;
 
-        await ctx.reply(message, { parse_mode: "HTML" });
-      } catch (error) {
-        await ctx.reply(
-          `❌ Error: ${error instanceof Error ? error.message : String(error)}`
-        );
-      }
+          await ctx.reply(message, { parse_mode: "HTML" });
+        } catch (error) {
+          await ctx.reply(
+            `❌ Error: ${error instanceof Error ? error.message : String(error)}`
+          );
+        }
+      })();
     });
 
     // #146: Dashboard command
     this.bot.command('dashboard', async (ctx: any) => {
-      await ctx.reply(
-        `📊 <b>Chen Pilot Dashboard</b>\n\nAccess your admin dashboard here:\n🔗 <a href="${DASHBOARD_URL}">Open Dashboard</a>\n\n<i>Note: You must be logged in to view the dashboard.</i>`,
-        { parse_mode: 'HTML' }
-      );
+      const userId = String(ctx.from?.id || 'unknown');
+      await withPerformanceProfiling('/dashboard', 'telegram', userId, async () => {
+        await ctx.reply(
+          `📊 <b>Chen Pilot Dashboard</b>\n\nAccess your admin dashboard here:\n🔗 <a href="${DASHBOARD_URL}">Open Dashboard</a>\n\n<i>Note: You must be logged in to view the dashboard.</i>`,
+          { parse_mode: 'HTML' }
+        );
+      })();
     });
 
     // #148: /validate command for Stellar asset verification
     this.bot.command('validate', async (ctx: any) => {
-      const args = ctx.message.text.split(' ').slice(1);
-      if (args.length < 2) {
-        return ctx.reply('Usage: /validate <assetCode> <issuerAddress>\nExample: /validate USDC GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5');
-      }
+      const userId = String(ctx.from?.id || 'unknown');
+      const commandName = extractCommandName(ctx.message.text, 'telegram');
+      await withPerformanceProfiling(commandName, 'telegram', userId, async () => {
+        const args = ctx.message.text.split(' ').slice(1);
+        if (args.length < 2) {
+          return ctx.reply('Usage: /validate <assetCode> <issuerAddress>\nExample: /validate USDC GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5');
+        }
 
-      const [assetCode, issuerAddress] = args;
-      await ctx.reply(`🔍 Verifying asset <b>${assetCode}</b> from issuer <code>${issuerAddress.slice(0, 8)}...</code>`, { parse_mode: 'HTML' });
+        const [assetCode, issuerAddress] = args;
+        await ctx.reply(`🔍 Verifying asset <b>${assetCode}</b> from issuer <code>${issuerAddress.slice(0, 8)}...</code>`, { parse_mode: 'HTML' });
 
-      try {
-        const result = await this.verificationService.verifyAsset(assetCode, issuerAddress);
-        const statusEmoji = result.status === 'VERIFIED' ? '✅' : result.status === 'MALICIOUS' ? '🚨' : '⚠️';
+        try {
+          const result = await this.verificationService.verifyAsset(assetCode, issuerAddress);
+          const statusEmoji = result.status === 'VERIFIED' ? '✅' : result.status === 'MALICIOUS' ? '🚨' : '⚠️';
 
-        let reply = `${statusEmoji} <b>Asset Verification: ${result.status}</b>\n\n`;
-        reply += `<b>Asset:</b> ${assetCode}\n`;
-        reply += `<b>Issuer:</b> <code>${issuerAddress}</code>\n`;
-        if (result.domain) reply += `<b>Domain:</b> ${result.domain}\n`;
-        if (result.details) reply += `<b>Details:</b> ${result.details}\n`;
-        reply += `\n<b>Safe to use:</b> ${result.isSafe ? 'Yes ✅' : 'No ❌'}`;
+          let reply = `${statusEmoji} <b>Asset Verification: ${result.status}</b>\n\n`;
+          reply += `<b>Asset:</b> ${assetCode}\n`;
+          reply += `<b>Issuer:</b> <code>${issuerAddress}</code>\n`;
+          if (result.domain) reply += `<b>Domain:</b> ${result.domain}\n`;
+          if (result.details) reply += `<b>Details:</b> ${result.details}\n`;
+          reply += `\n<b>Safe to use:</b> ${result.isSafe ? 'Yes ✅' : 'No ❌'}`;
 
-        await ctx.reply(reply, { parse_mode: 'HTML' });
-      } catch (error) {
-        await ctx.reply(`❌ Verification error: ${error instanceof Error ? error.message : String(error)}`);
-      }
-      return next();
+          await ctx.reply(reply, { parse_mode: 'HTML' });
+        } catch (error) {
+          await ctx.reply(`❌ Verification error: ${error instanceof Error ? error.message : String(error)}`);
+        }
+      })();
     });
+
     // Set bot commands for mobile menu
     await this.bot.telegram.setMyCommands([
       { command: "start", description: "Start the bot" },

--- a/packages/bot/src/performanceProfiler.ts
+++ b/packages/bot/src/performanceProfiler.ts
@@ -1,0 +1,99 @@
+/**
+ * Performance Profiler for Bot Commands
+ * 
+ * This module provides utilities to measure and log the execution time
+ * of bot command handlers to the backend for performance monitoring.
+ */
+
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:3000";
+
+export interface CommandPerformanceMetrics {
+  command: string;
+  platform: 'discord' | 'telegram';
+  userId: string;
+  executionTimeMs: number;
+  success: boolean;
+  error?: string;
+  timestamp: string;
+}
+
+/**
+ * Log command execution metrics to the backend
+ */
+async function logCommandMetrics(metrics: CommandPerformanceMetrics): Promise<void> {
+  try {
+    await fetch(`${BACKEND_URL}/api/bot/metrics`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(metrics),
+    });
+  } catch (error) {
+    // Fail silently - don't interrupt bot operation if logging fails
+    console.error('Failed to log command metrics:', error);
+  }
+}
+
+/**
+ * Wrap a command handler with performance profiling
+ * 
+ * @param command - The command name (e.g., '!help', '/start')
+ * @param platform - The platform ('discord' or 'telegram')
+ * @param userId - The user ID
+ * @param handler - The command handler function to wrap
+ * @returns A wrapped function that measures execution time
+ */
+export function withPerformanceProfiling<T extends (...args: any[]) => Promise<any>>(
+  command: string,
+  platform: 'discord' | 'telegram',
+  userId: string,
+  handler: T
+): T {
+  return (async (...args: Parameters<T>) => {
+    const startTime = Date.now();
+    let success = true;
+    let error: string | undefined;
+
+    try {
+      const result = await handler(...args);
+      return result;
+    } catch (err) {
+      success = false;
+      error = err instanceof Error ? err.message : String(err);
+      throw err; // Re-throw to maintain original error handling
+    } finally {
+      const executionTimeMs = Date.now() - startTime;
+      
+      // Log metrics asynchronously (don't await)
+      logCommandMetrics({
+        command,
+        platform,
+        userId,
+        executionTimeMs,
+        success,
+        error,
+        timestamp: new Date().toISOString(),
+      }).catch(() => {
+        // Fail silently
+      });
+
+      // Also log to console for immediate visibility
+      console.log(`[Bot Performance] ${platform} ${command} by ${userId}: ${executionTimeMs}ms${success ? '' : ' (failed)'}`);
+    }
+  }) as T;
+}
+
+/**
+ * Extract command name from message content
+ */
+export function extractCommandName(content: string, platform: 'discord' | 'telegram'): string {
+  const prefix = platform === 'discord' ? '!' : '/';
+  const parts = content.trim().split(' ');
+  return parts[0] || 'unknown';
+}
+
+/**
+ * Determine if execution time is slow (threshold: 2 seconds)
+ */
+export function isSlowExecution(executionTimeMs: number): boolean {
+  return executionTimeMs > 2000;
+}

--- a/src/AuditLog/auditLog.entity.ts
+++ b/src/AuditLog/auditLog.entity.ts
@@ -43,6 +43,17 @@ export enum AuditAction {
   // Data access
   DATA_EXPORT = "data_export",
   SENSITIVE_DATA_ACCESS = "sensitive_data_access",
+
+  // Bot commands
+  BOT_COMMAND_START = "bot_command_start",
+  BOT_COMMAND_HELP = "bot_command_help",
+  BOT_COMMAND_THREAD = "bot_command_thread",
+  BOT_COMMAND_SPONSOR = "bot_command_sponsor",
+  BOT_COMMAND_TRUSTLINE = "bot_command_trustline",
+  BOT_COMMAND_DASHBOARD = "bot_command_dashboard",
+  BOT_COMMAND_VALIDATE = "bot_command_validate",
+  BOT_COMMAND_BALANCE = "bot_command_balance",
+  BOT_COMMAND_SWAP = "bot_command_swap",
 }
 
 export enum AuditSeverity {

--- a/src/Gateway/routes.ts
+++ b/src/Gateway/routes.ts
@@ -117,6 +117,79 @@ router.use("/audit", auditLogRoutes);
 // Mount admin agent management routes (requires admin role)
 router.use("/admin/agents", adminAgentRoutes);
 
+// #149: Bot command performance metrics endpoint
+router.post("/bot/metrics", async (req: Request, res: Response) => {
+  try {
+    const { command, platform, userId, executionTimeMs, success, error, timestamp } = req.body;
+
+    // Validate required fields
+    if (!command || !platform || !userId || executionTimeMs === undefined) {
+      return res.status(400).json({
+        success: false,
+        message: "Missing required fields: command, platform, userId, executionTimeMs"
+      });
+    }
+
+    // Map bot command to audit action
+    const commandMap: Record<string, AuditAction> = {
+      '!start': AuditAction.BOT_COMMAND_START,
+      '/start': AuditAction.BOT_COMMAND_START,
+      '!help': AuditAction.BOT_COMMAND_HELP,
+      '/help': AuditAction.BOT_COMMAND_HELP,
+      '!thread': AuditAction.BOT_COMMAND_THREAD,
+      '!sponsor': AuditAction.BOT_COMMAND_SPONSOR,
+      '!trustline': AuditAction.BOT_COMMAND_TRUSTLINE,
+      '/trustline': AuditAction.BOT_COMMAND_TRUSTLINE,
+      '!dashboard': AuditAction.BOT_COMMAND_DASHBOARD,
+      '/dashboard': AuditAction.BOT_COMMAND_DASHBOARD,
+      '!validate': AuditAction.BOT_COMMAND_VALIDATE,
+      '/validate': AuditAction.BOT_COMMAND_VALIDATE,
+      '!balance': AuditAction.BOT_COMMAND_BALANCE,
+      '/balance': AuditAction.BOT_COMMAND_BALANCE,
+      '!swap': AuditAction.BOT_COMMAND_SWAP,
+      '/swap': AuditAction.BOT_COMMAND_SWAP,
+    };
+
+    const auditAction = commandMap[command] || AuditAction.BOT_COMMAND_START;
+
+    // Log to audit log
+    await auditLogService.log({
+      userId,
+      action: auditAction,
+      severity: success ? AuditSeverity.INFO : AuditSeverity.WARNING,
+      resource: `${platform}:${command}`,
+      metadata: {
+        platform,
+        command,
+        executionTimeMs,
+        timestamp,
+      },
+      errorMessage: error,
+      success,
+    });
+
+    // Also log to application logger for visibility
+    logger.info("Bot command performance metrics received", {
+      platform,
+      command,
+      userId,
+      executionTimeMs,
+      success,
+    });
+
+    return res.status(200).json({
+      success: true,
+      message: "Metrics logged successfully"
+    });
+  } catch (error) {
+    logger.error("Error logging bot metrics", { error, body: req.body });
+    return res.status(500).json({
+      success: false,
+      message: "Failed to log metrics"
+    });
+  }
+});
+
 // Public webhook endpoint for Stellar funding notifications
 router.post(
   "/webhook/stellar/funding",


### PR DESCRIPTION
successfully implemented bot command performance profiling metrics (issue #149) and pushed to the feat branch. Here's what was completed:
Changes Made
Fixed DEBOUNCE_MS constant - Added to both Discord and Telegram adapters
Added bot command AuditActions - Extended AuditAction enum with 9 bot-specific actions
Created performance profiler - New performanceProfiler.ts module with:
withPerformanceProfiling() wrapper function
logCommandMetrics() to send data to backend
extractCommandName() helper
isSlowExecution() threshold check
Wrapped Discord commands - All commands (!start, !help, !thread, !sponsor, !trustline, !dashboard, !validate) now profile execution time
Wrapped Telegram commands - All commands (/start, /help, /trustline, /dashboard, /validate) now profile execution time
Created backend endpoint - POST /api/bot/metrics receives and logs performance data to audit log
Push Details
closes #149 