### PR TITLE
feat: implement per-user rate limiting for bot commands 

### DIFF
--- a/packages/bot/src/adapters/discord.ts
+++ b/packages/bot/src/adapters/discord.ts
@@ -15,24 +15,18 @@ import {
 } from "@chen-pilot/sdk-core";
 import { searchFeatures, formatHelpMessage } from "../services/helpProvider";
 import { AssetVerificationService } from '../assetVerification';
+import { RateLimiter, DEFAULT_RATE_LIMIT, STRICT_RATE_LIMIT } from '../rateLimiter';
 
 const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:3000";
 const DASHBOARD_URL = process.env.DASHBOARD_URL || `${BACKEND_URL}/dashboard`;
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+const DEBOUNCE_MS = 1000; // 1 second debounce between commands
 
 // Commands that involve personal account data and must only be used in DMs
 const DM_ONLY_COMMANDS = ['!balance', '!sponsor'];
 
-function isDM(message: Message): boolean {
-  return message.channel.type === ChannelType.DM;
-}
-
-async function rejectPublicChannel(message: Message): Promise<void> {
-  await message.reply('🔒 This command contains sensitive account data and can only be used in a Direct Message (DM) with the bot.');
-}
-
-// Commands that involve personal account data and must only be used in DMs
-const DM_ONLY_COMMANDS = ['!balance', '!sponsor'];
+// Commands that require stricter rate limiting
+const SENSITIVE_COMMANDS = ['!sponsor', '!trustline', '!validate'];
 
 function isDM(message: Message): boolean {
   return message.channel.type === ChannelType.DM;
@@ -48,6 +42,9 @@ export class DiscordAdapter {
   private token: string;
   // #145: Track last command timestamp per user
   private lastCommandTime: Map<string, number> = new Map();
+  // #123: Rate limiters for bot commands
+  private defaultRateLimiter: RateLimiter;
+  private strictRateLimiter: RateLimiter;
   private verificationService: AssetVerificationService;
 
   constructor(token: string, auditLogChannelId?: string) {
@@ -61,6 +58,9 @@ export class DiscordAdapter {
       ],
     });
     this.verificationService = new AssetVerificationService(HORIZON_URL);
+    // #123: Initialize rate limiters
+    this.defaultRateLimiter = new RateLimiter(DEFAULT_RATE_LIMIT);
+    this.strictRateLimiter = new RateLimiter(STRICT_RATE_LIMIT);
   }
 
   // #145: Returns true if the user is flooding (within debounce window)
@@ -70,6 +70,25 @@ export class DiscordAdapter {
     if (now - last < DEBOUNCE_MS) return true;
     this.lastCommandTime.set(userId, now);
     return false;
+  }
+
+  // #123: Check rate limit for a user and command
+  private checkRateLimit(userId: string, command: string): { allowed: boolean; message?: string } {
+    // Determine which rate limiter to use based on command
+    const isSensitive = SENSITIVE_COMMANDS.some(cmd => command.startsWith(cmd));
+    const rateLimiter = isSensitive ? this.strictRateLimiter : this.defaultRateLimiter;
+    
+    const status = rateLimiter.check(userId);
+    
+    if (!status.allowed) {
+      const retryAfter = status.retryAfter || 60;
+      return {
+        allowed: false,
+        message: `⏳ Rate limit exceeded. Please wait ${retryAfter} seconds before trying again.`
+      };
+    }
+    
+    return { allowed: true };
   }
 
   async init() {
@@ -88,10 +107,18 @@ export class DiscordAdapter {
       if (message.author.bot) return;
 
       const userId = message.author.id;
+      const command = message.content.split(' ')[0];
 
       // #145: Anti-flood check for all commands
       if (this.isFlooding(userId)) {
         await message.reply("⏳ Please wait a moment before sending another command.");
+        return;
+      }
+
+      // #123: Rate limit check
+      const rateLimitResult = this.checkRateLimit(userId, command);
+      if (!rateLimitResult.allowed) {
+        await message.reply(rateLimitResult.message);
         return;
       }
 

--- a/packages/bot/src/adapters/telegram.ts
+++ b/packages/bot/src/adapters/telegram.ts
@@ -3,12 +3,17 @@ import { TransactionNotificationData } from "../types";
 import { createTrustlineOperation } from "@chen-pilot/sdk-core";
 import { searchFeatures, formatHelpMessage } from "../services/helpProvider";
 import { AssetVerificationService } from '../assetVerification';
+import { RateLimiter, DEFAULT_RATE_LIMIT, STRICT_RATE_LIMIT } from '../rateLimiter';
 
 const DASHBOARD_URL = process.env.DASHBOARD_URL || `${process.env.API_BASE_URL || 'http://localhost:2333'}/dashboard`;
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org';
+const DEBOUNCE_MS = 1000; // 1 second debounce between commands
 
 // Commands that involve personal account data and must only be used in DMs
 const DM_ONLY_COMMANDS = ['/balance'];
+
+// Commands that require stricter rate limiting
+const SENSITIVE_COMMANDS = ['/trustline', '/validate'];
 
 function isDM(ctx: Parameters<Parameters<Telegraf['command']>[1]>[0]): boolean {
   return ctx.chat?.type === 'private';
@@ -24,11 +29,17 @@ export class TelegramAdapter {
   private userChatIds: Map<string, string> = new Map(); // userId -> chatId
   // #145: Track last command timestamp per user
   private lastCommandTime: Map<number, number> = new Map();
+  // #123: Rate limiters for bot commands
+  private defaultRateLimiter: RateLimiter;
+  private strictRateLimiter: RateLimiter;
   private verificationService: AssetVerificationService;
 
   constructor(token: string) {
     this.token = token;
     this.verificationService = new AssetVerificationService(HORIZON_URL);
+    // #123: Initialize rate limiters
+    this.defaultRateLimiter = new RateLimiter(DEFAULT_RATE_LIMIT);
+    this.strictRateLimiter = new RateLimiter(STRICT_RATE_LIMIT);
   }
 
   // #145: Returns true if the user is flooding (within debounce window)
@@ -38,6 +49,25 @@ export class TelegramAdapter {
     if (now - last < DEBOUNCE_MS) return true;
     this.lastCommandTime.set(userId, now);
     return false;
+  }
+
+  // #123: Check rate limit for a user and command
+  private checkRateLimit(userId: number, command: string): { allowed: boolean; message?: string } {
+    // Determine which rate limiter to use based on command
+    const isSensitive = SENSITIVE_COMMANDS.some(cmd => command.startsWith(cmd));
+    const rateLimiter = isSensitive ? this.strictRateLimiter : this.defaultRateLimiter;
+    
+    const status = rateLimiter.check(String(userId));
+    
+    if (!status.allowed) {
+      const retryAfter = status.retryAfter || 60;
+      return {
+        allowed: false,
+        message: `⏳ Rate limit exceeded. Please wait ${retryAfter} seconds before trying again.`
+      };
+    }
+    
+    return { allowed: true };
   }
 
   async init() {
@@ -55,6 +85,17 @@ export class TelegramAdapter {
         await ctx.reply("⏳ Please wait a moment before sending another command.");
         return;
       }
+      
+      // #123: Rate limit check
+      const command = ctx.message?.text?.split(' ')[0] || '';
+      if (userId) {
+        const rateLimitResult = this.checkRateLimit(userId, command);
+        if (!rateLimitResult.allowed) {
+          await ctx.reply(rateLimitResult.message);
+          return;
+        }
+      }
+      
       return next();
     });
 
@@ -133,8 +174,8 @@ export class TelegramAdapter {
       } catch (error) {
         await ctx.reply(`❌ Verification error: ${error instanceof Error ? error.message : String(error)}`);
       }
-      return next();
     });
+
     // Set bot commands for mobile menu
     await this.bot.telegram.setMyCommands([
       { command: "start", description: "Start the bot" },

--- a/packages/bot/src/rateLimiter.ts
+++ b/packages/bot/src/rateLimiter.ts
@@ -1,0 +1,132 @@
+/**
+ * Rate Limiter for Bot Commands
+ * 
+ * Implements a sliding window rate limiter to prevent individual users
+ * from flooding the bot with commands.
+ */
+
+export interface RateLimitConfig {
+  maxRequests: number;      // Maximum number of requests allowed
+  windowMs: number;         // Time window in milliseconds
+}
+
+export interface RateLimitStatus {
+  allowed: boolean;
+  remaining: number;
+  resetTime: number;
+  retryAfter?: number;
+}
+
+export class RateLimiter {
+  private userTimestamps: Map<string, number[]> = new Map();
+  private config: RateLimitConfig;
+
+  constructor(config: RateLimitConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Check if a request is allowed for a given user
+   * 
+   * @param userId - The user identifier
+   * @returns Rate limit status
+   */
+  check(userId: string): RateLimitStatus {
+    const now = Date.now();
+    const timestamps = this.userTimestamps.get(userId) || [];
+    
+    // Filter out timestamps outside the current window
+    const windowStart = now - this.config.windowMs;
+    const validTimestamps = timestamps.filter(ts => ts > windowStart);
+    
+    // Update the stored timestamps
+    this.userTimestamps.set(userId, validTimestamps);
+    
+    const requestCount = validTimestamps.length;
+    const remaining = Math.max(0, this.config.maxRequests - requestCount);
+    const allowed = requestCount < this.config.maxRequests;
+    
+    if (allowed) {
+      // Add current timestamp
+      validTimestamps.push(now);
+      this.userTimestamps.set(userId, validTimestamps);
+    } else {
+      // Calculate retry after time (when oldest request expires)
+      const oldestTimestamp = validTimestamps[0];
+      const retryAfter = Math.ceil((oldestTimestamp + this.config.windowMs - now) / 1000);
+      
+      return {
+        allowed: false,
+        remaining: 0,
+        resetTime: oldestTimestamp + this.config.windowMs,
+        retryAfter,
+      };
+    }
+    
+    return {
+      allowed: true,
+      remaining: remaining - 1,
+      resetTime: now + this.config.windowMs,
+    };
+  }
+
+  /**
+   * Reset rate limit for a specific user
+   * 
+   * @param userId - The user identifier
+   */
+  reset(userId: string): void {
+    this.userTimestamps.delete(userId);
+  }
+
+  /**
+   * Clear all rate limit data (useful for testing)
+   */
+  clear(): void {
+    this.userTimestamps.clear();
+  }
+
+  /**
+   * Get current rate limit status without consuming a request
+   * 
+   * @param userId - The user identifier
+   * @returns Current rate limit status
+   */
+  getStatus(userId: string): RateLimitStatus {
+    const now = Date.now();
+    const timestamps = this.userTimestamps.get(userId) || [];
+    
+    // Filter out timestamps outside the current window
+    const windowStart = now - this.config.windowMs;
+    const validTimestamps = timestamps.filter(ts => ts > windowStart);
+    
+    const requestCount = validTimestamps.length;
+    const remaining = Math.max(0, this.config.maxRequests - requestCount);
+    const allowed = requestCount < this.config.maxRequests;
+    
+    let retryAfter: number | undefined;
+    if (!allowed && validTimestamps.length > 0) {
+      const oldestTimestamp = validTimestamps[0];
+      retryAfter = Math.ceil((oldestTimestamp + this.config.windowMs - now) / 1000);
+    }
+    
+    return {
+      allowed,
+      remaining,
+      resetTime: now + this.config.windowMs,
+      retryAfter,
+    };
+  }
+}
+
+// Default rate limit configuration
+export const DEFAULT_RATE_LIMIT: RateLimitConfig = {
+  maxRequests: 10,      // 10 requests
+  windowMs: 60000,      // per minute (60 seconds)
+};
+
+// Strict rate limit for sensitive operations
+export const STRICT_RATE_LIMIT: RateLimitConfig = {
+  maxRequests: 3,       // 3 requests
+  windowMs: 60000,      // per minute
+};


### PR DESCRIPTION
successfully implemented per-user rate limiting for bot commands (issue #123) and pushed to the build branch. Here's what was completed:

Implementation Summary
1. Created Rate Limiter Module
New file: packages/bot/src/rateLimiter.ts
Implements sliding window rate limiting algorithm
Tracks request timestamps per user
Configurable limits:
Default: 10 requests per minute
Strict: 3 requests per minute (for sensitive operations)
Provides rate limit status with retry-after time
2. Updated Discord Adapter
Added rate limiter instances (default and strict)
Added checkRateLimit() method to validate requests
Integrated rate limit check in message handler
Sensitive commands (!sponsor, !trustline, !validate) use stricter limits
User-friendly error messages with retry time
3. Updated Telegram Adapter
Added rate limiter instances (default and strict)
Added checkRateLimit() method to validate requests
Integrated rate limit check in middleware
Sensitive commands (/trustline, /validate) use stricter limits
User-friendly error messages with retry time
4. Fixed DEBOUNCE_MS Constant
Added missing DEBOUNCE_MS = 1000 constant to both adapters
This was referenced but not defined in the original codecloses #123