### PR TITLE
Feat: [Bot] Add support for Bot Session Persistence (Database)

### DIFF
--- a/packages/bot/src/sessionManager.ts
+++ b/packages/bot/src/sessionManager.ts
@@ -1,0 +1,182 @@
+/**
+ * Bot Session Manager
+ * 
+ * Manages bot session persistence by communicating with the backend API.
+ * This allows interactive bot sessions (wizards, multi-step flows) to survive bot restarts.
+ */
+
+export interface BotSessionData {
+  userId: string;
+  platform: 'discord' | 'telegram';
+  sessionType: 'multisig_wizard' | 'swap_wizard' | 'custom_flow';
+  step: number;
+  sessionData: Record<string, unknown>;
+  expiresAt?: string;
+}
+
+export interface BotSessionResponse {
+  success: boolean;
+  session?: {
+    id: string;
+    userId: string;
+    platform: string;
+    sessionType: string;
+    step: number;
+    sessionData: Record<string, unknown>;
+    expiresAt?: string;
+    isActive: boolean;
+    createdAt: string;
+    updatedAt: string;
+  };
+  message?: string;
+}
+
+export class SessionManager {
+  private backendUrl: string;
+
+  constructor(backendUrl?: string) {
+    this.backendUrl = backendUrl || process.env.BACKEND_URL || "http://localhost:3000";
+  }
+
+  /**
+   * Create or update a bot session
+   */
+  async saveSession(data: BotSessionData): Promise<BotSessionResponse> {
+    try {
+      const response = await fetch(`${this.backendUrl}/api/bot/session`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(data),
+      });
+
+      const result = await response.json() as BotSessionResponse;
+      return result;
+    } catch (error) {
+      console.error('Error saving bot session:', error);
+      return {
+        success: false,
+        message: 'Failed to save session',
+      };
+    }
+  }
+
+  /**
+   * Get active session for a user
+   */
+  async getSession(
+    userId: string,
+    platform: 'discord' | 'telegram',
+    sessionType: 'multisig_wizard' | 'swap_wizard' | 'custom_flow'
+  ): Promise<BotSessionResponse> {
+    try {
+      const params = new URLSearchParams({
+        userId,
+        platform,
+        sessionType,
+      });
+
+      const response = await fetch(`${this.backendUrl}/api/bot/session?${params}`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      const result = await response.json() as BotSessionResponse;
+      return result;
+    } catch (error) {
+      console.error('Error getting bot session:', error);
+      return {
+        success: false,
+        message: 'Failed to get session',
+      };
+    }
+  }
+
+  /**
+   * Update an existing session
+   */
+  async updateSession(
+    sessionId: string,
+    updates: Partial<{
+      step: number;
+      sessionData: Record<string, unknown>;
+      expiresAt: string;
+      isActive: boolean;
+    }>
+  ): Promise<BotSessionResponse> {
+    try {
+      const response = await fetch(`${this.backendUrl}/api/bot/session/${sessionId}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(updates),
+      });
+
+      const result = await response.json() as BotSessionResponse;
+      return result;
+    } catch (error) {
+      console.error('Error updating bot session:', error);
+      return {
+        success: false,
+        message: 'Failed to update session',
+      };
+    }
+  }
+
+  /**
+   * Deactivate a session
+   */
+  async deactivateSession(sessionId: string): Promise<BotSessionResponse> {
+    try {
+      const response = await fetch(`${this.backendUrl}/api/bot/session/${sessionId}`, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      const result = await response.json() as BotSessionResponse;
+      return result;
+    } catch (error) {
+      console.error('Error deactivating bot session:', error);
+      return {
+        success: false,
+        message: 'Failed to deactivate session',
+      };
+    }
+  }
+
+  /**
+   * Deactivate all sessions for a user
+   */
+  async deactivateUserSessions(
+    userId: string,
+    platform?: 'discord' | 'telegram'
+  ): Promise<BotSessionResponse> {
+    try {
+      const url = platform
+        ? `${this.backendUrl}/api/bot/sessions/user/${userId}?platform=${platform}`
+        : `${this.backendUrl}/api/bot/sessions/user/${userId}`;
+
+      const response = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+
+      const result = await response.json() as BotSessionResponse;
+      return result;
+    } catch (error) {
+      console.error('Error deactivating user sessions:', error);
+      return {
+        success: false,
+        message: 'Failed to deactivate sessions',
+      };
+    }
+  }
+}

--- a/src/Bot/botSession.entity.ts
+++ b/src/Bot/botSession.entity.ts
@@ -1,0 +1,58 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from "typeorm";
+
+export enum BotSessionType {
+  MULTISIG_WIZARD = "multisig_wizard",
+  SWAP_WIZARD = "swap_wizard",
+  CUSTOM_FLOW = "custom_flow",
+}
+
+export enum BotPlatform {
+  DISCORD = "discord",
+  TELEGRAM = "telegram",
+}
+
+@Entity()
+@Index(["userId", "platform"])
+@Index(["sessionType", "createdAt"])
+@Index(["platform", "userId", "expiresAt"])
+export class BotSession {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar" })
+  @Index()
+  userId!: string;
+
+  @Column({ type: "enum", enum: BotPlatform })
+  platform!: BotPlatform;
+
+  @Column({ type: "enum", enum: BotSessionType })
+  sessionType!: BotSessionType;
+
+  @Column({ type: "int" })
+  step!: number;
+
+  @Column({ type: "jsonb" })
+  sessionData!: Record<string, unknown>;
+
+  @Column({ type: "timestamp", nullable: true })
+  expiresAt?: Date;
+
+  @Column({ type: "boolean", default: true })
+  isActive!: boolean;
+
+  @CreateDateColumn()
+  @Index()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  @Index()
+  updatedAt!: Date;
+}

--- a/src/Bot/botSession.service.ts
+++ b/src/Bot/botSession.service.ts
@@ -1,0 +1,264 @@
+import { Repository, LessThan } from "typeorm";
+import AppDataSource from "../config/Datasource";
+import { BotSession, BotSessionType, BotPlatform } from "./botSession.entity";
+import logger from "../config/logger";
+
+export interface CreateBotSessionParams {
+  userId: string;
+  platform: BotPlatform;
+  sessionType: BotSessionType;
+  step: number;
+  sessionData: Record<string, unknown>;
+  expiresAt?: Date;
+}
+
+export interface UpdateBotSessionParams {
+  step?: number;
+  sessionData?: Record<string, unknown>;
+  expiresAt?: Date;
+  isActive?: boolean;
+}
+
+export interface BotSessionQuery {
+  userId?: string;
+  platform?: BotPlatform;
+  sessionType?: BotSessionType;
+  isActive?: boolean;
+}
+
+export class BotSessionService {
+  private botSessionRepository: Repository<BotSession>;
+
+  constructor() {
+    this.botSessionRepository = AppDataSource.getRepository(BotSession);
+  }
+
+  /**
+   * Create a new bot session
+   */
+  async create(params: CreateBotSessionParams): Promise<BotSession> {
+    try {
+      // Check if there's an existing active session for this user/platform/type
+      const existingSession = await this.findActiveSession(
+        params.userId,
+        params.platform,
+        params.sessionType
+      );
+
+      if (existingSession) {
+        // Update existing session instead of creating a new one
+        return this.update(existingSession.id, {
+          step: params.step,
+          sessionData: params.sessionData,
+          expiresAt: params.expiresAt,
+          isActive: true,
+        });
+      }
+
+      const session = this.botSessionRepository.create({
+        userId: params.userId,
+        platform: params.platform,
+        sessionType: params.sessionType,
+        step: params.step,
+        sessionData: params.sessionData,
+        expiresAt: params.expiresAt,
+        isActive: true,
+      });
+
+      const savedSession = await this.botSessionRepository.save(session);
+      logger.info("Bot session created", {
+        sessionId: savedSession.id,
+        userId: params.userId,
+        platform: params.platform,
+        sessionType: params.sessionType,
+      });
+
+      return savedSession;
+    } catch (error) {
+      logger.error("Error creating bot session", { error, params });
+      throw error;
+    }
+  }
+
+  /**
+   * Update an existing bot session
+   */
+  async update(sessionId: string, params: UpdateBotSessionParams): Promise<BotSession> {
+    try {
+      const session = await this.botSessionRepository.findOne({ where: { id: sessionId } });
+      if (!session) {
+        throw new Error(`Session with id ${sessionId} not found`);
+      }
+
+      if (params.step !== undefined) session.step = params.step;
+      if (params.sessionData !== undefined) session.sessionData = params.sessionData;
+      if (params.expiresAt !== undefined) session.expiresAt = params.expiresAt;
+      if (params.isActive !== undefined) session.isActive = params.isActive;
+
+      const updatedSession = await this.botSessionRepository.save(session);
+      logger.info("Bot session updated", {
+        sessionId: updatedSession.id,
+        userId: updatedSession.userId,
+        platform: updatedSession.platform,
+      });
+
+      return updatedSession;
+    } catch (error) {
+      logger.error("Error updating bot session", { error, sessionId, params });
+      throw error;
+    }
+  }
+
+  /**
+   * Find an active session for a user/platform/type
+   */
+  async findActiveSession(
+    userId: string,
+    platform: BotPlatform,
+    sessionType: BotSessionType
+  ): Promise<BotSession | null> {
+    try {
+      const session = await this.botSessionRepository.findOne({
+        where: {
+          userId,
+          platform,
+          sessionType,
+          isActive: true,
+          expiresAt: undefined as any, // Will be handled by cleanup
+        },
+        order: { createdAt: "DESC" },
+      });
+
+      // Check if session has expired
+      if (session && session.expiresAt && session.expiresAt < new Date()) {
+        await this.deactivateSession(session.id);
+        return null;
+      }
+
+      return session || null;
+    } catch (error) {
+      logger.error("Error finding active bot session", { error, userId, platform, sessionType });
+      throw error;
+    }
+  }
+
+  /**
+   * Get a session by ID
+   */
+  async getById(sessionId: string): Promise<BotSession | null> {
+    try {
+      const session = await this.botSessionRepository.findOne({ where: { id: sessionId } });
+      
+      // Check if session has expired
+      if (session && session.expiresAt && session.expiresAt < new Date()) {
+        await this.deactivateSession(session.id);
+        return null;
+      }
+
+      return session || null;
+    } catch (error) {
+      logger.error("Error getting bot session by ID", { error, sessionId });
+      throw error;
+    }
+  }
+
+  /**
+   * Deactivate a session
+   */
+  async deactivateSession(sessionId: string): Promise<void> {
+    try {
+      await this.botSessionRepository.update(sessionId, { isActive: false });
+      logger.info("Bot session deactivated", { sessionId });
+    } catch (error) {
+      logger.error("Error deactivating bot session", { error, sessionId });
+      throw error;
+    }
+  }
+
+  /**
+   * Delete a session
+   */
+  async deleteSession(sessionId: string): Promise<void> {
+    try {
+      await this.botSessionRepository.delete(sessionId);
+      logger.info("Bot session deleted", { sessionId });
+    } catch (error) {
+      logger.error("Error deleting bot session", { error, sessionId });
+      throw error;
+    }
+  }
+
+  /**
+   * Query sessions with filters
+   */
+  async query(query: BotSessionQuery): Promise<BotSession[]> {
+    try {
+      const where: any = {};
+      if (query.userId) where.userId = query.userId;
+      if (query.platform) where.platform = query.platform;
+      if (query.sessionType) where.sessionType = query.sessionType;
+      if (query.isActive !== undefined) where.isActive = query.isActive;
+
+      const sessions = await this.botSessionRepository.find({
+        where,
+        order: { createdAt: "DESC" },
+      });
+
+      // Filter out expired sessions
+      const now = new Date();
+      const activeSessions = sessions.filter(
+        (session) => !session.expiresAt || session.expiresAt > now
+      );
+
+      return activeSessions;
+    } catch (error) {
+      logger.error("Error querying bot sessions", { error, query });
+      throw error;
+    }
+  }
+
+  /**
+   * Clean up expired sessions
+   */
+  async cleanupExpiredSessions(): Promise<number> {
+    try {
+      const now = new Date();
+      const result = await this.botSessionRepository.update(
+        {
+          expiresAt: LessThan(now),
+          isActive: true,
+        },
+        { isActive: false }
+      );
+
+      const affectedCount = result.affected || 0;
+      if (affectedCount > 0) {
+        logger.info("Expired bot sessions cleaned up", { count: affectedCount });
+      }
+
+      return affectedCount;
+    } catch (error) {
+      logger.error("Error cleaning up expired bot sessions", { error });
+      throw error;
+    }
+  }
+
+  /**
+   * Deactivate all active sessions for a user
+   */
+  async deactivateUserSessions(userId: string, platform?: BotPlatform): Promise<number> {
+    try {
+      const where: any = { userId, isActive: true };
+      if (platform) where.platform = platform;
+
+      const result = await this.botSessionRepository.update(where, { isActive: false });
+      const affectedCount = result.affected || 0;
+
+      logger.info("User bot sessions deactivated", { userId, platform, count: affectedCount });
+      return affectedCount;
+    } catch (error) {
+      logger.error("Error deactivating user bot sessions", { error, userId, platform });
+      throw error;
+    }
+  }
+}

--- a/src/Gateway/routes.ts
+++ b/src/Gateway/routes.ts
@@ -29,6 +29,8 @@ import {
 import { auditLogService } from "../AuditLog/auditLog.service";
 import { AuditAction, AuditSeverity } from "../AuditLog/auditLog.entity";
 import { getSocketManager } from "./socketManager";
+import { BotSessionService } from "../Bot/botSession.service";
+import { BotSessionType, BotPlatform } from "../Bot/botSession.entity";
 
 const router = Router();
 
@@ -186,6 +188,170 @@ router.post("/bot/metrics", async (req: Request, res: Response) => {
     return res.status(500).json({
       success: false,
       message: "Failed to log metrics"
+    });
+  }
+});
+
+// #126: Bot session management endpoints
+const botSessionService = new BotSessionService();
+
+// Create or update a bot session
+router.post("/bot/session", async (req: Request, res: Response) => {
+  try {
+    const { userId, platform, sessionType, step, sessionData, expiresAt } = req.body;
+
+    // Validate required fields
+    if (!userId || !platform || !sessionType || step === undefined || !sessionData) {
+      return res.status(400).json({
+        success: false,
+        message: "Missing required fields: userId, platform, sessionType, step, sessionData"
+      });
+    }
+
+    // Validate platform
+    if (!Object.values(BotPlatform).includes(platform)) {
+      return res.status(400).json({
+        success: false,
+        message: `Invalid platform. Must be one of: ${Object.values(BotPlatform).join(', ')}`
+      });
+    }
+
+    // Validate session type
+    if (!Object.values(BotSessionType).includes(sessionType)) {
+      return res.status(400).json({
+        success: false,
+        message: `Invalid session type. Must be one of: ${Object.values(BotSessionType).join(', ')}`
+      });
+    }
+
+    // Set default expiration (24 hours from now) if not provided
+    const expiration = expiresAt ? new Date(expiresAt) : new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    const session = await botSessionService.create({
+      userId,
+      platform,
+      sessionType,
+      step,
+      sessionData,
+      expiresAt: expiration,
+    });
+
+    return res.status(200).json({
+      success: true,
+      session,
+    });
+  } catch (error) {
+    logger.error("Error creating bot session", { error, body: req.body });
+    return res.status(500).json({
+      success: false,
+      message: "Failed to create session"
+    });
+  }
+});
+
+// Get active session for a user
+router.get("/bot/session", async (req: Request, res: Response) => {
+  try {
+    const { userId, platform, sessionType } = req.query;
+
+    if (!userId || !platform || !sessionType) {
+      return res.status(400).json({
+        success: false,
+        message: "Missing required query parameters: userId, platform, sessionType"
+      });
+    }
+
+    const session = await botSessionService.findActiveSession(
+      userId as string,
+      platform as BotPlatform,
+      sessionType as BotSessionType
+    );
+
+    if (!session) {
+      return res.status(404).json({
+        success: false,
+        message: "No active session found"
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      session,
+    });
+  } catch (error) {
+    logger.error("Error getting bot session", { error, query: req.query });
+    return res.status(500).json({
+      success: false,
+      message: "Failed to get session"
+    });
+  }
+});
+
+// Update a bot session
+router.put("/bot/session/:sessionId", async (req: Request, res: Response) => {
+  try {
+    const { sessionId } = req.params;
+    const { step, sessionData, expiresAt, isActive } = req.body;
+
+    const session = await botSessionService.update(sessionId, {
+      step,
+      sessionData,
+      expiresAt: expiresAt ? new Date(expiresAt) : undefined,
+      isActive,
+    });
+
+    return res.status(200).json({
+      success: true,
+      session,
+    });
+  } catch (error) {
+    logger.error("Error updating bot session", { error, params: req.params, body: req.body });
+    return res.status(500).json({
+      success: false,
+      message: "Failed to update session"
+    });
+  }
+});
+
+// Deactivate a bot session
+router.delete("/bot/session/:sessionId", async (req: Request, res: Response) => {
+  try {
+    const { sessionId } = req.params;
+    await botSessionService.deactivateSession(sessionId);
+
+    return res.status(200).json({
+      success: true,
+      message: "Session deactivated"
+    });
+  } catch (error) {
+    logger.error("Error deactivating bot session", { error, params: req.params });
+    return res.status(500).json({
+      success: false,
+      message: "Failed to deactivate session"
+    });
+  }
+});
+
+// Deactivate all sessions for a user
+router.delete("/bot/sessions/user/:userId", async (req: Request, res: Response) => {
+  try {
+    const { userId } = req.params;
+    const { platform } = req.query;
+
+    const count = await botSessionService.deactivateUserSessions(
+      userId,
+      platform as BotPlatform
+    );
+
+    return res.status(200).json({
+      success: true,
+      message: `${count} session(s) deactivated`
+    });
+  } catch (error) {
+    logger.error("Error deactivating user sessions", { error, params: req.params });
+    return res.status(500).json({
+      success: false,
+      message: "Failed to deactivate sessions"
     });
   }
 });

--- a/src/config/Datasource.ts
+++ b/src/config/Datasource.ts
@@ -12,6 +12,7 @@ import {
 } from "../Agents/registry/PromptVersion.entity";
 import { WebhookIdempotency } from "../Gateway/webhookIdempotency.entity";
 import { AuditLog } from "../AuditLog/auditLog.entity";
+import { BotSession } from "../Bot/botSession.entity";
 
 const isDev = config.env === "development";
 
@@ -34,6 +35,7 @@ const dbOptions: DataSourceOptions = {
     PromptMetric,
     WebhookIdempotency,
     AuditLog,
+    BotSession,
   ],
   migrations: [isDev ? "src/migrations/**/*.ts" : "dist/migrations/**/*.js"],
   subscribers: [],

--- a/src/migrations/1772400000000-CreateBotSession.ts
+++ b/src/migrations/1772400000000-CreateBotSession.ts
@@ -1,0 +1,133 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex, TableForeignKey } from "typeorm";
+
+export class CreateBotSession1772400000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: "bot_session",
+        columns: [
+          {
+            name: "id",
+            type: "uuid",
+            isPrimary: true,
+            generationStrategy: "uuid",
+            default: "uuid_generate_v4()",
+          },
+          {
+            name: "userId",
+            type: "varchar",
+            isNullable: false,
+          },
+          {
+            name: "platform",
+            type: "enum",
+            enum: ["discord", "telegram"],
+            isNullable: false,
+          },
+          {
+            name: "sessionType",
+            type: "enum",
+            enum: ["multisig_wizard", "swap_wizard", "custom_flow"],
+            isNullable: false,
+          },
+          {
+            name: "step",
+            type: "int",
+            isNullable: false,
+          },
+          {
+            name: "sessionData",
+            type: "jsonb",
+            isNullable: false,
+          },
+          {
+            name: "expiresAt",
+            type: "timestamp",
+            isNullable: true,
+          },
+          {
+            name: "isActive",
+            type: "boolean",
+            default: true,
+            isNullable: false,
+          },
+          {
+            name: "createdAt",
+            type: "timestamp",
+            default: "now()",
+            isNullable: false,
+          },
+          {
+            name: "updatedAt",
+            type: "timestamp",
+            default: "now()",
+            isNullable: false,
+          },
+        ],
+      }),
+      true
+    );
+
+    // Create indexes
+    await queryRunner.createIndex(
+      "bot_session",
+      new TableIndex({
+        name: "IDX_bot_session_userId",
+        columnNames: ["userId"],
+      })
+    );
+
+    await queryRunner.createIndex(
+      "bot_session",
+      new TableIndex({
+        name: "IDX_bot_session_userId_createdAt",
+        columnNames: ["userId", "createdAt"],
+      })
+    );
+
+    await queryRunner.createIndex(
+      "bot_session",
+      new TableIndex({
+        name: "IDX_bot_session_sessionType_createdAt",
+        columnNames: ["sessionType", "createdAt"],
+      })
+    );
+
+    await queryRunner.createIndex(
+      "bot_session",
+      new TableIndex({
+        name: "IDX_bot_session_platform_userId_expiresAt",
+        columnNames: ["platform", "userId", "expiresAt"],
+      })
+    );
+
+    await queryRunner.createIndex(
+      "bot_session",
+      new TableIndex({
+        name: "IDX_bot_session_createdAt",
+        columnNames: ["createdAt"],
+      })
+    );
+
+    await queryRunner.createIndex(
+      "bot_session",
+      new TableIndex({
+        name: "IDX_bot_session_updatedAt",
+        columnNames: ["updatedAt"],
+      })
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Drop indexes
+    await queryRunner.dropIndex("bot_session", "IDX_bot_session_userId");
+    await queryRunner.dropIndex("bot_session", "IDX_bot_session_userId_createdAt");
+    await queryRunner.dropIndex("bot_session", "IDX_bot_session_sessionType_createdAt");
+    await queryRunner.dropIndex("bot_session", "IDX_bot_session_platform_userId_expiresAt");
+    await queryRunner.dropIndex("bot_session", "IDX_bot_session_createdAt");
+    await queryRunner.dropIndex("bot_session", "IDX_bot_session_updatedAt");
+
+    // Drop table
+    await queryRunner.dropTable("bot_session");
+  }
+}


### PR DESCRIPTION
closes #126 
Implementation Summary
Backend Components
BotSession Entity (src/Bot/botSession.entity.ts)
Fields: userId, platform (discord/telegram), sessionType (multisig_wizard/swap_wizard/custom_flow), step, sessionData (JSONB), expiresAt, isActive, timestamps
Indexed on userId, platform, sessionType, and expiration for efficient queries
BotSessionService (src/Bot/botSession.service.ts)
create() - Create or update session (updates existing if found)
update() - Update session step/data
findActiveSession() - Get active session for user/platform/type
deactivateSession() - Mark session as inactive
deactivateUserSessions() - Deactivate all sessions for a user
cleanupExpiredSessions() - Clean up expired sessions
API Endpoints (src/Gateway/routes.ts)
POST /api/bot/session - Create/update session
GET /api/bot/session - Get active session
PUT /api/bot/session/:sessionId - Update session
DELETE /api/bot/session/:sessionId - Deactivate session
DELETE /api/bot/sessions/user/:userId - Deactivate all user sessions
Database Migration (src/migrations/1772400000000-CreateBotSession.ts)
Creates bot_session table with all required columns
Adds indexes for performance optimization
Bot Package Components
SessionManager (packages/bot/src/sessionManager.ts)
Client library for bot adapters to communicate with backend API
Methods: saveSession, getSession, updateSession, deactivateSession, deactivateUserSessions
Handles API communication and error handling
Configuration
Updated Datasource to include BotSession entity
The implementation allows interactive bot sessions (wizards, multi-step flows) to persist in the database, surviving bot restarts. Bot adapters can now integrate session persistence by using the SessionManager to save and restore session state.