### PR TITLE
[Bot] Implement /portfolio command with summary visualization

### DIFF
--- a/packages/bot/src/adapters/discord.ts
+++ b/packages/bot/src/adapters/discord.ts
@@ -31,7 +31,7 @@ const ADVANCED_ROLE_NAMES = (process.env.DISCORD_ADVANCED_ROLES || 'DeFi Pro,Wha
 const SUPPORTED_CURRENCIES = ['USD', 'XLM', 'BTC'] as const;
 
 // Commands that involve personal account data and must only be used in DMs
-const DM_ONLY_COMMANDS = ['!balance', '!sponsor'];
+const DM_ONLY_COMMANDS = ['!balance', '!sponsor', '!portfolio'];
 
 // Commands that start a wizard
 const WIZARD_COMMANDS = ['!multisig'];
@@ -372,6 +372,67 @@ export class DiscordAdapter {
         } catch {
           return message.reply(`❌ Could not fetch portfolio. Make sure your account is registered.`);
         }
+      }
+
+      // !portfolio command — rich formatted portfolio summary with net worth
+      if (message.content.startsWith('!portfolio')) {
+        if (!isDM(message)) {
+          await rejectPublicChannel(message);
+          return;
+        }
+        await withPerformanceProfiling('!portfolio', 'discord', userId, async () => {
+          const args = message.content.split(' ').slice(1);
+          const currency = (args[0]?.toUpperCase() ?? this.userCurrency.get(userId) ?? 'USD') as 'USD' | 'XLM' | 'BTC';
+          if (!SUPPORTED_CURRENCIES.includes(currency as any)) {
+            return message.reply(`❌ Unsupported currency. Use one of: ${SUPPORTED_CURRENCIES.join(', ')}\nExample: \`!portfolio USD\``);
+          }
+
+          await message.reply(`⏳ Fetching your Stellar portfolio in **${currency}**...`);
+
+          try {
+            const res = await fetch(`${BACKEND_URL}/api/portfolio/${userId}?currency=${currency}`);
+            if (!res.ok) {
+              const err = await res.json() as { message?: string };
+              throw new Error(err.message ?? `HTTP ${res.status}`);
+            }
+
+            const data = await res.json() as {
+              address: string;
+              currency: string;
+              totalValue: number | null;
+              assets: { code: string; issuer: string; balance: number; value: number | null }[];
+              fetchedAt: string;
+            };
+
+            const shortAddr = `\`${data.address.slice(0, 4)}...${data.address.slice(-4)}\``;
+            const netWorth = data.totalValue !== null
+              ? `**${data.totalValue.toFixed(4)} ${data.currency}**`
+              : '*unavailable*';
+
+            let reply = `💼 **Stellar Portfolio Summary**\n`;
+            reply += `📬 Account: ${shortAddr}\n`;
+            reply += `💰 **Net Worth:** ${netWorth}\n`;
+            reply += `🕐 Updated: ${new Date(data.fetchedAt).toUTCString()}\n\n`;
+            reply += `**Assets:**\n`;
+
+            if (data.assets.length === 0) {
+              reply += '_No assets found on this account._\n';
+            } else {
+              for (const a of data.assets) {
+                const valueStr = a.value !== null
+                  ? ` ≈ ${a.value.toFixed(4)} ${data.currency}`
+                  : '';
+                const issuerStr = a.issuer ? ` (\`${a.issuer.slice(0, 6)}...\`)` : '';
+                reply += `• **${a.code}**${issuerStr}: ${a.balance.toFixed(7)}${valueStr}\n`;
+              }
+            }
+
+            reply += `\n_Tip: Use \`!currency <USD|XLM|BTC>\` to change your default currency._`;
+            return message.reply(reply);
+          } catch (err) {
+            return message.reply(`❌ Could not fetch portfolio: ${err instanceof Error ? err.message : String(err)}\nMake sure your account is registered with \`!sponsor\`.`);
+          }
+        })();
       }
 
       // #119: !alert command — set a price alert

--- a/packages/bot/src/adapters/telegram.ts
+++ b/packages/bot/src/adapters/telegram.ts
@@ -7,12 +7,13 @@ import { RateLimiter, DEFAULT_RATE_LIMIT, STRICT_RATE_LIMIT } from '../rateLimit
 import { withPerformanceProfiling, extractCommandName } from '../performanceProfiler';
 import { MultisigWizard } from '../multisigWizard';
 
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:3000";
 const DASHBOARD_URL = process.env.DASHBOARD_URL || `${process.env.API_BASE_URL || 'http://localhost:2333'}/dashboard`;
 const HORIZON_URL = process.env.STELLAR_HORIZON_URL || 'https://horizon-testnet.stellar.org';
 const DEBOUNCE_MS = 1000; // 1 second debounce between commands
 
 // Commands that involve personal account data and must only be used in DMs
-const DM_ONLY_COMMANDS = ['/balance'];
+const DM_ONLY_COMMANDS = ['/balance', '/portfolio'];
 
 // Commands that start a wizard
 const WIZARD_COMMANDS = ['/multisig'];
@@ -202,9 +203,80 @@ export class TelegramAdapter {
       })();
     });
 
-    // #125: Multisig wizard command
-    this.bot.command('multisig', async (ctx: any) => {
+    // /portfolio command — rich formatted portfolio summary with net worth
+    this.bot.command('portfolio', async (ctx: any) => {
       const userId = String(ctx.from?.id || 'unknown');
+      const commandName = extractCommandName(ctx.message.text, 'telegram');
+
+      if (!isDM(ctx)) {
+        await rejectPublicChannel(ctx);
+        return;
+      }
+
+      await withPerformanceProfiling(commandName, 'telegram', userId, async () => {
+        const args = ctx.message.text.split(' ').slice(1);
+        const SUPPORTED = ['USD', 'XLM', 'BTC'];
+        const currency = (args[0]?.toUpperCase() ?? 'USD');
+
+        if (!SUPPORTED.includes(currency)) {
+          return ctx.reply(`❌ Unsupported currency. Use one of: ${SUPPORTED.join(', ')}\nExample: <code>/portfolio USD</code>`, { parse_mode: 'HTML' });
+        }
+
+        await ctx.reply(`⏳ Fetching your Stellar portfolio in <b>${currency}</b>...`, { parse_mode: 'HTML' });
+
+        try {
+          const res = await fetch(`${BACKEND_URL}/api/portfolio/${userId}?currency=${currency}`);
+          if (!res.ok) {
+            const err = await res.json() as { message?: string };
+            throw new Error(err.message ?? `HTTP ${res.status}`);
+          }
+
+          const data = await res.json() as {
+            address: string;
+            currency: string;
+            totalValue: number | null;
+            assets: { code: string; issuer: string; balance: number; value: number | null }[];
+            fetchedAt: string;
+          };
+
+          const shortAddr = `<code>${data.address.slice(0, 4)}...${data.address.slice(-4)}</code>`;
+          const netWorth = data.totalValue !== null
+            ? `<b>${data.totalValue.toFixed(4)} ${data.currency}</b>`
+            : '<i>unavailable</i>';
+
+          let reply = `💼 <b>Stellar Portfolio Summary</b>\n`;
+          reply += `📬 Account: ${shortAddr}\n`;
+          reply += `💰 <b>Net Worth:</b> ${netWorth}\n`;
+          reply += `🕐 Updated: ${new Date(data.fetchedAt).toUTCString()}\n\n`;
+          reply += `<b>Assets:</b>\n`;
+
+          if (data.assets.length === 0) {
+            reply += '<i>No assets found on this account.</i>\n';
+          } else {
+            for (const a of data.assets) {
+              const valueStr = a.value !== null
+                ? ` ≈ ${a.value.toFixed(4)} ${data.currency}`
+                : '';
+              const issuerStr = a.issuer
+                ? ` (<code>${a.issuer.slice(0, 6)}...</code>)`
+                : '';
+              reply += `• <b>${a.code}</b>${issuerStr}: ${a.balance.toFixed(7)}${valueStr}\n`;
+            }
+          }
+
+          reply += `\n<i>Tip: Use /portfolio &lt;USD|XLM|BTC&gt; to choose a currency.</i>`;
+          return ctx.reply(reply, { parse_mode: 'HTML' });
+        } catch (err) {
+          return ctx.reply(
+            `❌ Could not fetch portfolio: ${err instanceof Error ? err.message : String(err)}\nMake sure your account is registered with /sponsor.`,
+            { parse_mode: 'HTML' }
+          );
+        }
+      })();
+    });
+
+    // #125: Multisig wizard command
+    this.bot.command('multisig', async (ctx: any) => {      const userId = String(ctx.from?.id || 'unknown');
       if (!isDM(ctx)) {
         await rejectPublicChannel(ctx);
         return;
@@ -234,6 +306,7 @@ export class TelegramAdapter {
     await this.bot.telegram.setMyCommands([
       { command: "start", description: "Start the bot" },
       { command: "balance", description: "Check wallet balance" },
+      { command: "portfolio", description: "Full portfolio summary & net worth" },
       { command: "swap", description: "Swap assets" },
       { command: "trustline", description: "Add trustline" },
       { command: "multisig", description: "Setup multisig wallet" },

--- a/packages/bot/src/services/helpProvider.ts
+++ b/packages/bot/src/services/helpProvider.ts
@@ -52,6 +52,22 @@ const FEATURES: BotFeature[] = [
     command: "/price",
     keywords: ["price", "market", "cost", "value", "rate", "quote"],
   },
+  {
+    name: "Portfolio Summary",
+    description:
+      "View a formatted summary of all your Stellar asset balances and estimated net worth in USD, XLM, or BTC.",
+    command: "/portfolio",
+    keywords: [
+      "portfolio",
+      "net worth",
+      "summary",
+      "holdings",
+      "assets",
+      "total",
+      "wealth",
+      "overview",
+    ],
+  },
 ];
 
 export function searchFeatures(query: string): BotFeature[] {

--- a/src/AuditLog/auditLog.entity.ts
+++ b/src/AuditLog/auditLog.entity.ts
@@ -54,6 +54,7 @@ export enum AuditAction {
   BOT_COMMAND_VALIDATE = "bot_command_validate",
   BOT_COMMAND_BALANCE = "bot_command_balance",
   BOT_COMMAND_SWAP = "bot_command_swap",
+  BOT_COMMAND_PORTFOLIO = "bot_command_portfolio",
 }
 
 export enum AuditSeverity {

--- a/src/Gateway/routes.ts
+++ b/src/Gateway/routes.ts
@@ -31,6 +31,7 @@ import { AuditAction, AuditSeverity } from "../AuditLog/auditLog.entity";
 import { getSocketManager } from "./socketManager";
 import { BotSessionService } from "../Bot/botSession.service";
 import { BotSessionType, BotPlatform } from "../Bot/botSession.entity";
+import portfolioService from "../services/portfolioService";
 
 const router = Router();
 
@@ -150,6 +151,8 @@ router.post("/bot/metrics", async (req: Request, res: Response) => {
       '/balance': AuditAction.BOT_COMMAND_BALANCE,
       '!swap': AuditAction.BOT_COMMAND_SWAP,
       '/swap': AuditAction.BOT_COMMAND_SWAP,
+      '!portfolio': AuditAction.BOT_COMMAND_PORTFOLIO,
+      '/portfolio': AuditAction.BOT_COMMAND_PORTFOLIO,
     };
 
     const auditAction = commandMap[command] || AuditAction.BOT_COMMAND_START;
@@ -1052,5 +1055,97 @@ router.post(
     }
   }
 );
+
+// -----------------------------------------------------------------------
+// Portfolio endpoints
+// -----------------------------------------------------------------------
+
+/**
+ * GET /api/portfolio/:userId?currency=USD
+ *
+ * Returns a formatted portfolio summary for the user's Stellar account,
+ * including all asset balances and estimated net worth in the requested
+ * currency (USD | XLM | BTC, default USD).
+ */
+router.get(
+  "/portfolio/:userId",
+  authenticateToken,
+  requireOwnerOrElevated("userId"),
+  async (req: Request, res: Response) => {
+    try {
+      const { userId } = req.params;
+      const currency = (req.query.currency as string | undefined) ?? "USD";
+
+      const userRepository = AppDataSource.getRepository(User);
+      const user = await userRepository.findOne({ where: { id: userId } });
+      if (!user) {
+        return res
+          .status(404)
+          .json({ success: false, message: "User not found" });
+      }
+
+      const summary = await portfolioService.getPortfolio(user.address, currency);
+
+      await auditLogService.log({
+        userId,
+        action: AuditAction.BOT_COMMAND_PORTFOLIO,
+        severity: AuditSeverity.INFO,
+        resource: `portfolio:${userId}`,
+        metadata: { currency, address: user.address },
+        success: true,
+      });
+
+      return res.status(200).json({
+        success: true,
+        address: summary.address,
+        currency: summary.currency,
+        totalValue: summary.totalValue,
+        assets: summary.assets.map((a) => ({
+          code: a.code,
+          issuer: a.issuer,
+          balance: a.amount,
+          value: a.valueInCurrency,
+        })),
+        fetchedAt: summary.fetchedAt,
+      });
+    } catch (error) {
+      logger.error("Portfolio fetch error", { error, userId: req.params.userId });
+      const message =
+        error instanceof Error ? error.message : "Internal server error";
+      const statusCode =
+        message.includes("not found") || message.includes("unreachable")
+          ? 404
+          : 500;
+      return res.status(statusCode).json({ success: false, message });
+    }
+  }
+);
+
+/**
+ * GET /api/price/:assetCode?currency=USD
+ *
+ * Returns the current DEX price of an asset in the requested currency.
+ */
+router.get("/price/:assetCode", async (req: Request, res: Response) => {
+  try {
+    const { assetCode } = req.params;
+    const currency = (req.query.currency as string | undefined) ?? "USD";
+
+    const result = await portfolioService.getAssetPrice(assetCode, currency);
+
+    return res.status(200).json({
+      success: true,
+      assetCode: result.assetCode,
+      currency: result.currency,
+      price: result.price,
+    });
+  } catch (error) {
+    logger.error("Price fetch error", { error, assetCode: req.params.assetCode });
+    return res.status(500).json({
+      success: false,
+      message: error instanceof Error ? error.message : "Internal server error",
+    });
+  }
+});
 
 export default router;

--- a/src/services/portfolioService.ts
+++ b/src/services/portfolioService.ts
@@ -1,0 +1,198 @@
+/**
+ * Portfolio Service
+ *
+ * Fetches a user's Stellar account balances from Horizon and calculates
+ * net worth by pricing each asset against a target currency via the DEX.
+ */
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+import config from "../config/config";
+import logger from "../config/logger";
+import stellarPriceService from "./stellarPrice.service";
+
+export interface AssetBalance {
+  /** Asset code, e.g. "XLM", "USDC" */
+  code: string;
+  /** Issuer public key, empty string for native XLM */
+  issuer: string;
+  /** Raw balance string from Horizon */
+  balance: string;
+  /** Numeric balance */
+  amount: number;
+  /** Estimated value in the requested currency (null if price unavailable) */
+  valueInCurrency: number | null;
+  /** Whether this is the native XLM asset */
+  isNative: boolean;
+}
+
+export interface PortfolioSummary {
+  /** Stellar account address */
+  address: string;
+  /** Currency used for net-worth calculation */
+  currency: string;
+  /** All asset balances on the account */
+  assets: AssetBalance[];
+  /** Sum of all asset values in the requested currency (null if no prices available) */
+  totalValue: number | null;
+  /** ISO timestamp of when this snapshot was taken */
+  fetchedAt: string;
+}
+
+// Currencies we can price assets against via the DEX
+const SUPPORTED_CURRENCIES = ["USD", "XLM", "BTC"] as const;
+type SupportedCurrency = (typeof SUPPORTED_CURRENCIES)[number];
+
+// Well-known anchor issuers for common stablecoins so we can attempt DEX pricing
+const KNOWN_ISSUERS: Record<string, string> = {
+  USDC: "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
+  USDT: "GCQTGZQQ5G4PTM2GL7CDIFKUBIPEC52BROAQIAPW53XBRJVN6ZJVTG6V",
+};
+
+export class PortfolioService {
+  private server: StellarSdk.Horizon.Server;
+
+  constructor() {
+    this.server = new StellarSdk.Horizon.Server(config.stellar.horizonUrl);
+  }
+
+  /**
+   * Fetch all balances for a Stellar account and price them in the given currency.
+   *
+   * @param address  Stellar public key (G…)
+   * @param currency Target currency for net-worth calculation (default: "USD")
+   */
+  async getPortfolio(
+    address: string,
+    currency: string = "USD"
+  ): Promise<PortfolioSummary> {
+    const normalizedCurrency = currency.toUpperCase() as SupportedCurrency;
+
+    if (!SUPPORTED_CURRENCIES.includes(normalizedCurrency)) {
+      throw new Error(
+        `Unsupported currency "${currency}". Supported: ${SUPPORTED_CURRENCIES.join(", ")}`
+      );
+    }
+
+    // Fetch account from Horizon
+    let account: StellarSdk.Horizon.AccountResponse;
+    try {
+      account = await this.server.accounts().accountId(address).call();
+    } catch (err) {
+      logger.error("PortfolioService: failed to load account", { address, err });
+      throw new Error(`Account not found or Horizon unreachable: ${address}`);
+    }
+
+    const rawBalances: StellarSdk.Horizon.HorizonApi.BalanceLine[] =
+      account.balances as StellarSdk.Horizon.HorizonApi.BalanceLine[];
+
+    // Build asset list
+    const assets: AssetBalance[] = rawBalances.map((b) => {
+      const isNative = b.asset_type === "native";
+      const code = isNative
+        ? "XLM"
+        : (b as StellarSdk.Horizon.HorizonApi.BalanceLineAsset).asset_code;
+      const issuer = isNative
+        ? ""
+        : (b as StellarSdk.Horizon.HorizonApi.BalanceLineAsset).asset_issuer;
+      const amount = parseFloat(b.balance);
+
+      return {
+        code,
+        issuer,
+        balance: b.balance,
+        amount,
+        valueInCurrency: null, // filled in below
+        isNative,
+      };
+    });
+
+    // Price each asset
+    await Promise.all(
+      assets.map(async (asset) => {
+        if (asset.amount === 0) {
+          asset.valueInCurrency = 0;
+          return;
+        }
+
+        try {
+          if (asset.code === normalizedCurrency) {
+            // Asset IS the target currency — 1:1
+            asset.valueInCurrency = asset.amount;
+            return;
+          }
+
+          // For XLM priced in XLM — trivial
+          if (asset.code === "XLM" && normalizedCurrency === "XLM") {
+            asset.valueInCurrency = asset.amount;
+            return;
+          }
+
+          // Attempt DEX price lookup
+          const fromCode = asset.code;
+          const toCode = normalizedCurrency;
+
+          // Only attempt pricing for assets we know how to look up
+          const isKnown =
+            asset.isNative || Object.keys(KNOWN_ISSUERS).includes(fromCode);
+
+          if (!isKnown) {
+            // Unknown asset — skip pricing
+            return;
+          }
+
+          const quote = await stellarPriceService.getPrice(
+            fromCode,
+            toCode,
+            asset.amount
+          );
+          asset.valueInCurrency = quote.estimatedOutput;
+        } catch (err) {
+          // Price unavailable — leave as null
+          logger.warn(
+            `PortfolioService: could not price ${asset.code} in ${normalizedCurrency}`,
+            { err }
+          );
+        }
+      })
+    );
+
+    // Sum total value (only include assets where price is known)
+    const pricedAssets = assets.filter((a) => a.valueInCurrency !== null);
+    const totalValue =
+      pricedAssets.length > 0
+        ? pricedAssets.reduce((sum, a) => sum + (a.valueInCurrency ?? 0), 0)
+        : null;
+
+    return {
+      address,
+      currency: normalizedCurrency,
+      assets,
+      totalValue,
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Get the current price of a single asset in the given currency.
+   *
+   * @param assetCode  e.g. "XLM", "USDC"
+   * @param currency   e.g. "USD", "XLM", "BTC"
+   */
+  async getAssetPrice(
+    assetCode: string,
+    currency: string = "USD"
+  ): Promise<{ assetCode: string; currency: string; price: number }> {
+    const from = assetCode.toUpperCase();
+    const to = currency.toUpperCase();
+
+    if (from === to) {
+      return { assetCode: from, currency: to, price: 1 };
+    }
+
+    const quote = await stellarPriceService.getPrice(from, to, 1);
+    return { assetCode: from, currency: to, price: quote.price };
+  }
+}
+
+export const portfolioService = new PortfolioService();
+export default portfolioService;


### PR DESCRIPTION
#110 Implement /portfolio command with summary visualization
- Add PortfolioService that fetches Horizon balances and prices assets via DEX
- Add GET /api/portfolio/:userId and GET /api/price/:assetCode endpoints
- Add BOT_COMMAND_PORTFOLIO audit action
- Add !portfolio command to Discord (DM-only, markdown formatted)
- Add /portfolio command to Telegram (DM-only, HTML formatted)
- Both commands support USD, XLM, BTC currency selection
- Register Portfolio Summary in help provider for discoverability