### PR TITLE
Build a backend-wide observability model with traceable

### DIFF
--- a/src/Auth/auth.middleware.ts
+++ b/src/Auth/auth.middleware.ts
@@ -1,10 +1,15 @@
 import { Request, Response, NextFunction } from "express";
 import { container } from "tsyringe";
 import JwtService from "./jwt.service";
+import { updateObservabilityContext } from "../observability";
 
 // Extend Express Request type to include user
 declare module "express-serve-static-core" {
   interface Request {
+    requestId?: string;
+    executionId?: string;
+    rootExecutionId?: string;
+    parentExecutionId?: string;
     user?: {
       userId: string;
       name: string;
@@ -43,6 +48,7 @@ export async function authenticateToken(
       name: payload.name,
       role: payload.role,
     };
+    updateObservabilityContext({ userId: payload.userId });
 
     next();
   } catch {
@@ -73,6 +79,7 @@ export async function optionalAuth(
         name: payload.name,
         role: payload.role,
       };
+      updateObservabilityContext({ userId: payload.userId });
     }
 
     next();

--- a/src/Gateway/api.ts
+++ b/src/Gateway/api.ts
@@ -9,6 +9,7 @@ import authRoutes from "./auth.routes";
 import { swaggerSpec } from "./swagger";
 import requestLogger from "../middleware/requestLogger";
 import { ipBlacklistMiddleware, ipBlacklistRoutes } from "../Security";
+import { observabilityMiddleware, updateObservabilityContext } from "../observability";
 
 import { authenticate } from "../Auth/auth";
 import UserService from "../Auth/user.service";
@@ -33,6 +34,7 @@ app.use(
 );
 
 app.use(express.json());
+app.use(observabilityMiddleware);
 app.use(requestLogger);
 app.use(ipBlacklistMiddleware);
 
@@ -168,6 +170,11 @@ app.post("/query", sensitiveLimiter, async (req, res, next) => {
   // app.post("/query", async (req, res, next) => {
   try {
     const { userId, query } = req.body;
+    updateObservabilityContext({
+      userId,
+      operationName: "agent.query",
+      component: "http.query",
+    });
 
     const user = await authenticate(userId);
 

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,6 +1,7 @@
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
 import path from "path";
+import { getObservabilityLogFields } from "../observability";
 
 // Sensitive fields to redact from logs
 const SENSITIVE_FIELDS = ["pk", "privateKey", "password", "token", "secret"];
@@ -38,11 +39,13 @@ const redactFormat = winston.format((info: Record<string, unknown>) => {
 
   const { level, message, timestamp, ...meta } = info;
   const redactedMeta = redactSensitiveData(meta);
+  const contextFields = getObservabilityLogFields();
 
   return {
     level,
     message,
     timestamp,
+    ...contextFields,
     ...(typeof redactedMeta === "object" && redactedMeta !== null
       ? redactedMeta
       : {}),

--- a/src/middleware/requestLogger.ts
+++ b/src/middleware/requestLogger.ts
@@ -45,6 +45,9 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction) =
   logger.info("Incoming request", {
     method,
     url: originalUrl,
+    requestId: req.requestId,
+    executionId: req.executionId,
+    rootExecutionId: req.rootExecutionId,
     ip: ip || req.socket.remoteAddress,
     userAgent: headers["user-agent"],
     body: sanitizeObject(req.body),
@@ -58,6 +61,8 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction) =
     logger.info("Outgoing response", {
       method,
       url: originalUrl,
+      requestId: req.requestId,
+      executionId: req.executionId,
       statusCode: res.statusCode,
       duration: `${duration}ms`,
       response: sanitizeObject(body),
@@ -79,6 +84,8 @@ export const requestLogger = (req: Request, res: Response, next: NextFunction) =
       logger.warn("Request completed with error", {
         method,
         url: originalUrl,
+        requestId: req.requestId,
+        executionId: req.executionId,
         statusCode: res.statusCode,
         duration: `${duration}ms`,
       });

--- a/src/observability/context.ts
+++ b/src/observability/context.ts
@@ -1,0 +1,188 @@
+import { AsyncLocalStorage } from "async_hooks";
+import { randomUUID } from "crypto";
+
+export const REQUEST_ID_HEADER = "x-request-id";
+export const CORRELATION_ID_HEADER = "x-correlation-id";
+export const EXECUTION_ID_HEADER = "x-execution-id";
+export const ROOT_EXECUTION_ID_HEADER = "x-root-execution-id";
+export const PARENT_EXECUTION_ID_HEADER = "x-parent-execution-id";
+
+export interface ObservabilityContext {
+  requestId: string;
+  executionId: string;
+  rootExecutionId: string;
+  parentExecutionId?: string;
+  userId?: string;
+  operationName?: string;
+  component?: string;
+  queueName?: string;
+  jobId?: string;
+}
+
+type HeaderValue = string | string[] | undefined;
+
+const storage = new AsyncLocalStorage<ObservabilityContext>();
+
+function firstHeaderValue(value: HeaderValue): string | undefined {
+  if (Array.isArray(value)) {
+    return value[0];
+  }
+
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function getObservabilityContext():
+  | ObservabilityContext
+  | undefined {
+  return storage.getStore();
+}
+
+export function createObservabilityContext(
+  partial: Partial<ObservabilityContext> = {}
+): ObservabilityContext {
+  const requestId = partial.requestId || randomUUID();
+  const executionId = partial.executionId || randomUUID();
+  const rootExecutionId =
+    partial.rootExecutionId || partial.parentExecutionId || executionId;
+
+  return {
+    requestId,
+    executionId,
+    rootExecutionId,
+    parentExecutionId: partial.parentExecutionId,
+    userId: partial.userId,
+    operationName: partial.operationName,
+    component: partial.component,
+    queueName: partial.queueName,
+    jobId: partial.jobId,
+  };
+}
+
+export function runWithObservabilityContext<T>(
+  context: Partial<ObservabilityContext>,
+  callback: () => T
+): T {
+  const current = getObservabilityContext();
+  const nextContext = createObservabilityContext({
+    ...current,
+    ...context,
+    requestId: context.requestId || current?.requestId,
+    rootExecutionId: context.rootExecutionId || current?.rootExecutionId,
+    parentExecutionId: context.parentExecutionId || current?.parentExecutionId,
+  });
+
+  return storage.run(nextContext, callback);
+}
+
+export function withChildExecution<T>(
+  context: Partial<ObservabilityContext>,
+  callback: () => T
+): T {
+  const current = getObservabilityContext();
+  const requestId = context.requestId || current?.requestId || randomUUID();
+  const parentExecutionId =
+    context.parentExecutionId || current?.executionId || undefined;
+  const rootExecutionId =
+    context.rootExecutionId ||
+    current?.rootExecutionId ||
+    parentExecutionId ||
+    randomUUID();
+
+  return runWithObservabilityContext(
+    {
+      ...current,
+      ...context,
+      requestId,
+      executionId: context.executionId || randomUUID(),
+      rootExecutionId,
+      parentExecutionId,
+    },
+    callback
+  );
+}
+
+export function updateObservabilityContext(
+  updates: Partial<ObservabilityContext>
+): void {
+  const current = getObservabilityContext();
+  if (!current) {
+    return;
+  }
+
+  Object.assign(current, updates);
+}
+
+export function extractObservabilityContextFromHeaders(headers: {
+  [key: string]: HeaderValue;
+}): Partial<ObservabilityContext> {
+  const requestId =
+    firstHeaderValue(headers[REQUEST_ID_HEADER]) ||
+    firstHeaderValue(headers[CORRELATION_ID_HEADER]);
+  const executionId = firstHeaderValue(headers[EXECUTION_ID_HEADER]);
+  const rootExecutionId = firstHeaderValue(headers[ROOT_EXECUTION_ID_HEADER]);
+  const parentExecutionId = firstHeaderValue(
+    headers[PARENT_EXECUTION_ID_HEADER]
+  );
+
+  return {
+    requestId,
+    executionId,
+    rootExecutionId,
+    parentExecutionId,
+  };
+}
+
+export function buildCorrelationHeaders(
+  context: Partial<ObservabilityContext> = getObservabilityContext() || {}
+): Record<string, string> {
+  const resolved = createObservabilityContext(context);
+
+  return {
+    [REQUEST_ID_HEADER]: resolved.requestId,
+    [CORRELATION_ID_HEADER]: resolved.requestId,
+    [EXECUTION_ID_HEADER]: resolved.executionId,
+    [ROOT_EXECUTION_ID_HEADER]: resolved.rootExecutionId,
+    ...(resolved.parentExecutionId
+      ? { [PARENT_EXECUTION_ID_HEADER]: resolved.parentExecutionId }
+      : {}),
+  };
+}
+
+export function getObservabilityLogFields(): Record<string, string> {
+  const context = getObservabilityContext();
+  if (!context) {
+    return {};
+  }
+
+  const fields: Record<string, string> = {
+    requestId: context.requestId,
+    executionId: context.executionId,
+    rootExecutionId: context.rootExecutionId,
+  };
+
+  if (context.parentExecutionId) {
+    fields.parentExecutionId = context.parentExecutionId;
+  }
+
+  if (context.userId) {
+    fields.userId = context.userId;
+  }
+
+  if (context.operationName) {
+    fields.operationName = context.operationName;
+  }
+
+  if (context.component) {
+    fields.component = context.component;
+  }
+
+  if (context.queueName) {
+    fields.queueName = context.queueName;
+  }
+
+  if (context.jobId) {
+    fields.jobId = context.jobId;
+  }
+
+  return fields;
+}

--- a/src/observability/http.ts
+++ b/src/observability/http.ts
@@ -1,0 +1,31 @@
+import { NextFunction, Request, Response } from "express";
+import {
+  buildCorrelationHeaders,
+  createObservabilityContext,
+  extractObservabilityContextFromHeaders,
+  runWithObservabilityContext,
+} from "./context";
+
+export function observabilityMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  const initialContext = createObservabilityContext({
+    ...extractObservabilityContextFromHeaders(req.headers),
+    operationName: `${req.method} ${req.path}`,
+    component: "http",
+  });
+
+  req.requestId = initialContext.requestId;
+  req.executionId = initialContext.executionId;
+  req.rootExecutionId = initialContext.rootExecutionId;
+  req.parentExecutionId = initialContext.parentExecutionId;
+
+  const headers = buildCorrelationHeaders(initialContext);
+  Object.entries(headers).forEach(([headerName, value]) => {
+    res.setHeader(headerName, value);
+  });
+
+  runWithObservabilityContext(initialContext, () => next());
+}

--- a/src/observability/index.ts
+++ b/src/observability/index.ts
@@ -1,0 +1,2 @@
+export * from "./context";
+export * from "./http";


### PR DESCRIPTION
Closes #343

---

This PR lays the foundation for backend-wide observability by introducing a shared request/execution correlation model and wiring it into the HTTP entrypoint and logger stack.

What changed
Added a new observability module backed by AsyncLocalStorage to carry correlation context across async work.
Introduced standard correlation headers:
x-request-id
x-correlation-id
x-execution-id
x-root-execution-id
x-parent-execution-id
Added Express middleware that:
accepts inbound correlation headers when present
generates missing request/execution IDs
stores them in request-scoped context
echoes them back on responses
Extended Express Request typing so handlers and middleware can access correlation IDs directly.
Updated the Winston logger pipeline to automatically enrich all logs with the active observability context.
Updated request/response logging to include request and execution identifiers.
Updated auth middleware to attach userId into the active observability context after token resolution.
Updated the /query route to stamp the request context with operation-level metadata for agent queries.
Why
Before this change, logs were not consistently tied together across a single user operation. This makes it much easier to trace one request through the backend by giving every log line a shared correlation model, while still allowing child execution IDs to be layered in later for tools, queues, LLM calls, and blockchain actions.

Scope
This PR is the observability foundation layer. It primarily covers:

HTTP ingress correlation
request-scoped context propagation
structured log enrichment
Follow-up work can build on this to propagate child execution context deeper into tool execution, queued work, LLM provider calls, and blockchain submission paths.

Testing
No dedicated test coverage added yet.
This change is currently focused on infrastructure wiring and log/context propagation.