### PR TITLE
[Backend] Create a strong typed domain model for assets, quotes, balances, and path results (#339)

### DIFF
--- a/src/domain/__tests__/asset.test.ts
+++ b/src/domain/__tests__/asset.test.ts
@@ -1,0 +1,56 @@
+import { Asset, AssetAmount } from '../index';
+
+describe('Domain Models', () => {
+  describe('Asset', () => {
+    it('should create a native asset', () => {
+      const xlm = Asset.native();
+      expect(xlm.code).toBe('XLM');
+      expect(xlm.type).toBe('native');
+    });
+
+    it('should create a custom asset', () => {
+      const usdc = Asset.create({
+        code: 'USDC',
+        issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+        type: 'credit_alphanum4',
+        decimals: 7,
+      });
+      expect(usdc.code).toBe('USDC');
+      expect(usdc.issuer).toBeDefined();
+    });
+
+    it('should throw on invalid asset code', () => {
+      expect(() => {
+        Asset.create({
+          code: '',
+          type: 'credit_alphanum4',
+          decimals: 7,
+        });
+      }).toThrow();
+    });
+  });
+
+  describe('AssetAmount', () => {
+    it('should create a valid asset amount', () => {
+      const xlm = Asset.native();
+      const amount = AssetAmount.create(xlm, '100.5');
+      expect(amount.amount).toBe('100.5');
+      expect(amount.toString()).toBe('100.5 XLM');
+    });
+
+    it('should throw on negative amount', () => {
+      const xlm = Asset.native();
+      expect(() => {
+        AssetAmount.create(xlm, '-10');
+      }).toThrow();
+    });
+
+    it('should add amounts correctly', () => {
+      const xlm = Asset.native();
+      const amount1 = AssetAmount.create(xlm, '100');
+      const amount2 = AssetAmount.create(xlm, '50');
+      const sum = amount1.add(amount2);
+      expect(parseFloat(sum.amount)).toBe(150);
+    });
+  });
+});

--- a/src/domain/assets/asset.ts
+++ b/src/domain/assets/asset.ts
@@ -1,0 +1,86 @@
+import { ValueObject, validateAssetCode } from '../common';
+
+export type AssetType = 'native' | 'credit_alphanum4' | 'credit_alphanum12';
+
+export interface AssetProps {
+  code: string;
+  issuer?: string;
+  type: AssetType;
+  name?: string;
+  decimals: number;
+  metadata?: Record<string, unknown>;
+}
+
+export class Asset extends ValueObject<AssetProps> {
+  private constructor(props: AssetProps) {
+    super(props);
+  }
+
+  static create(props: AssetProps): Asset {
+    validateAssetCode(props.code);
+    
+    if (props.type !== 'native' && !props.issuer) {
+      throw new Error('Issuer is required for non-native assets');
+    }
+
+    if (props.type === 'native' && props.code !== 'XLM') {
+      throw new Error('Native asset code must be XLM');
+    }
+
+    return new Asset(props);
+  }
+
+  static native(): Asset {
+    return Asset.create({
+      code: 'XLM',
+      type: 'native',
+      decimals: 7,
+      name: 'Stellar Lumens',
+    });
+  }
+
+  get code(): string {
+    return this._value.code;
+  }
+
+  get issuer(): string | undefined {
+    return this._value.issuer;
+  }
+
+  get type(): AssetType {
+    return this._value.type;
+  }
+
+  get name(): string | undefined {
+    return this._value.name;
+  }
+
+  get decimals(): number {
+    return this._value.decimals;
+  }
+
+  get metadata(): Record<string, unknown> | undefined {
+    return this._value.metadata;
+  }
+
+  get canonicalId(): string {
+    if (this.type === 'native') {
+      return 'native:XLM';
+    }
+    return `${this.code}:${this.issuer}`;
+  }
+
+  toString(): string {
+    if (this.type === 'native') {
+      return 'XLM';
+    }
+    return `${this.code}-${this.issuer}`;
+  }
+}
+
+export interface AssetBalance {
+  asset: Asset;
+  amount: string;
+  buyingLiabilities: string;
+  sellingLiabilities: string;
+}

--- a/src/domain/assets/assetAmount.ts
+++ b/src/domain/assets/assetAmount.ts
@@ -1,0 +1,62 @@
+import { ValueObject, validatePositive, validateNonNegative } from '../common';
+import { Asset } from './asset';
+
+export interface AssetAmountProps {
+  asset: Asset;
+  amount: string;
+}
+
+export class AssetAmount extends ValueObject<AssetAmountProps> {
+  private constructor(props: AssetAmountProps) {
+    super(props);
+  }
+
+  static create(asset: Asset, amount: string): AssetAmount {
+    validateNonNegative(amount, 'amount');
+    return new AssetAmount({ asset, amount });
+  }
+
+  static createPositive(asset: Asset, amount: string): AssetAmount {
+    validatePositive(amount, 'amount');
+    return new AssetAmount({ asset, amount });
+  }
+
+  get asset(): Asset {
+    return this._value.asset;
+  }
+
+  get amount(): string {
+    return this._value.amount;
+  }
+
+  add(other: AssetAmount): AssetAmount {
+    if (!this.asset.equals(other.asset)) {
+      throw new Error('Cannot add different assets');
+    }
+    const sum = (parseFloat(this.amount) + parseFloat(other.amount)).toString();
+    return AssetAmount.create(this.asset, sum);
+  }
+
+  subtract(other: AssetAmount): AssetAmount {
+    if (!this.asset.equals(other.asset)) {
+      throw new Error('Cannot subtract different assets');
+    }
+    const diff = (parseFloat(this.amount) - parseFloat(other.amount)).toString();
+    return AssetAmount.create(this.asset, diff);
+  }
+
+  isZero(): boolean {
+    return parseFloat(this.amount) === 0;
+  }
+
+  isGreaterThan(other: AssetAmount): boolean {
+    if (!this.asset.equals(other.asset)) {
+      throw new Error('Cannot compare different assets');
+    }
+    return parseFloat(this.amount) > parseFloat(other.amount);
+  }
+
+  toString(): string {
+    return `${this.amount} ${this.asset.code}`;
+  }
+}

--- a/src/domain/assets/index.ts
+++ b/src/domain/assets/index.ts
@@ -1,0 +1,4 @@
+export { Asset, AssetType } from './asset';
+export type { AssetProps, AssetBalance } from './asset';
+export { AssetAmount } from './assetAmount';
+export type { AssetAmountProps } from './assetAmount';

--- a/src/domain/balances/balance.ts
+++ b/src/domain/balances/balance.ts
@@ -1,0 +1,75 @@
+import { Asset, AssetAmount } from '../assets';
+import { BaseEntity, Timestamp, UUID } from '../common';
+
+export interface BalanceProps {
+  accountId: UUID;
+  asset: Asset;
+  amount: string;
+  buyingLiabilities: string;
+  sellingLiabilities: string;
+  lastUpdated: Timestamp;
+}
+
+export class Balance implements BaseEntity {
+  constructor(
+    public readonly id: UUID,
+    public readonly accountId: UUID,
+    public readonly asset: Asset,
+    public readonly amount: string,
+    public readonly buyingLiabilities: string,
+    public readonly sellingLiabilities: string,
+    public readonly lastUpdated: Timestamp,
+    public readonly createdAt: Timestamp,
+    public readonly updatedAt: Timestamp,
+    public readonly version: number
+  ) {}
+
+  get availableBalance(): string {
+    const amount = parseFloat(this.amount);
+    const buying = parseFloat(this.buyingLiabilities);
+    const selling = parseFloat(this.sellingLiabilities);
+    return (amount - buying - selling).toString();
+  }
+
+  getAssetAmount(): AssetAmount {
+    return AssetAmount.create(this.asset, this.amount);
+  }
+
+  getAvailableAssetAmount(): AssetAmount {
+    return AssetAmount.create(this.asset, this.availableBalance);
+  }
+
+  canCover(amount: AssetAmount): boolean {
+    if (!this.asset.equals(amount.asset)) {
+      return false;
+    }
+    return parseFloat(this.availableBalance) >= parseFloat(amount.amount);
+  }
+}
+
+export interface BalanceMap {
+  [assetId: string]: Balance;
+}
+
+export class BalanceSnapshot {
+  constructor(
+    public readonly balances: BalanceMap,
+    public readonly timestamp: Timestamp,
+    public readonly blockNumber: number
+  ) {}
+
+  getBalanceForAsset(asset: Asset): Balance | undefined {
+    return this.balances[asset.canonicalId];
+  }
+
+  getTotalValueInNative(priceMap: Map<string, string>): string {
+    let total = 0;
+    for (const balance of Object.values(this.balances)) {
+      const price = priceMap.get(balance.asset.canonicalId);
+      if (price) {
+        total += parseFloat(balance.amount) * parseFloat(price);
+      }
+    }
+    return total.toString();
+  }
+}

--- a/src/domain/balances/index.ts
+++ b/src/domain/balances/index.ts
@@ -1,0 +1,2 @@
+export { Balance, BalanceSnapshot } from './balance';
+export type { BalanceProps, BalanceMap } from './balance';

--- a/src/domain/common/errors.ts
+++ b/src/domain/common/errors.ts
@@ -1,0 +1,34 @@
+export class DomainError extends Error {
+  constructor(message: string, public readonly code: string) {
+    super(message);
+    this.name = 'DomainError';
+  }
+}
+
+export class ValidationError extends DomainError {
+  constructor(message: string) {
+    super(message, 'VALIDATION_ERROR');
+    this.name = 'ValidationError';
+  }
+}
+
+export class InsufficientBalanceError extends DomainError {
+  constructor(asset: string, available: string, requested: string) {
+    super(`Insufficient balance for ${asset}: available ${available}, requested ${requested}`, 'INSUFFICIENT_BALANCE');
+    this.name = 'InsufficientBalanceError';
+  }
+}
+
+export class AssetNotFoundError extends DomainError {
+  constructor(assetCode: string) {
+    super(`Asset not found: ${assetCode}`, 'ASSET_NOT_FOUND');
+    this.name = 'AssetNotFoundError';
+  }
+}
+
+export class InvalidAmountError extends DomainError {
+  constructor(amount: string, reason: string) {
+    super(`Invalid amount ${amount}: ${reason}`, 'INVALID_AMOUNT');
+    this.name = 'InvalidAmountError';
+  }
+}

--- a/src/domain/common/types.ts
+++ b/src/domain/common/types.ts
@@ -1,0 +1,46 @@
+// Common type utilities
+export type Timestamp = string; // ISO 8601 format
+export type UUID = string;
+export type Address = string;
+export type Amount = string; // Decimal string for precision
+
+// Base entity interface
+export interface BaseEntity {
+  id: UUID;
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+  version: number;
+}
+
+// Result pattern for error handling
+export type Result<T, E = Error> = { success: true; data: T } | { success: false; error: E };
+
+// Pagination types
+export interface PaginationParams {
+  limit: number;
+  offset: number;
+}
+
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+// Value object base
+export abstract class ValueObject<T> {
+  protected readonly _value: T;
+
+  constructor(value: T) {
+    this._value = Object.freeze(value);
+  }
+
+  get value(): T {
+    return this._value;
+  }
+
+  equals(other: ValueObject<T>): boolean {
+    return JSON.stringify(this._value) === JSON.stringify(other._value);
+  }
+}

--- a/src/domain/common/validators.ts
+++ b/src/domain/common/validators.ts
@@ -1,0 +1,38 @@
+import { ValidationError } from './errors';
+
+export const validateNonNegative = (value: string, fieldName: string): void => {
+  const num = parseFloat(value);
+  if (isNaN(num)) {
+    throw new ValidationError(`${fieldName} must be a valid number, got ${value}`);
+  }
+  if (num < 0) {
+    throw new ValidationError(`${fieldName} cannot be negative, got ${value}`);
+  }
+};
+
+export const validatePositive = (value: string, fieldName: string): void => {
+  const num = parseFloat(value);
+  if (isNaN(num)) {
+    throw new ValidationError(`${fieldName} must be a valid number, got ${value}`);
+  }
+  if (num <= 0) {
+    throw new ValidationError(`${fieldName} must be positive, got ${value}`);
+  }
+};
+
+export const validateAddress = (address: string): void => {
+  // Stellar address format validation
+  const stellarAddressRegex = /^G[A-Z0-9]{55}$/;
+  if (!stellarAddressRegex.test(address)) {
+    throw new ValidationError(`Invalid Stellar address: ${address}`);
+  }
+};
+
+export const validateAssetCode = (code: string): void => {
+  if (!code || code.length < 1 || code.length > 12) {
+    throw new ValidationError(`Asset code must be 1-12 characters, got ${code}`);
+  }
+  if (!/^[A-Za-z0-9]+$/.test(code)) {
+    throw new ValidationError(`Asset code must be alphanumeric, got ${code}`);
+  }
+};

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,0 +1,22 @@
+// Common exports
+export * from './common/types';
+export * from './common/errors';
+export * from './common/validators';
+
+// Asset exports
+export * from './assets';
+
+// Balance exports
+export * from './balances';
+
+// Quote exports
+export * from './quotes';
+
+// Routing exports
+export * from './routing';
+
+// Convenience exports
+export { Asset, AssetAmount } from './assets';
+export { Balance, BalanceSnapshot } from './balances';
+export { Quote } from './quotes';
+export { Path } from './routing';

--- a/src/domain/quotes/index.ts
+++ b/src/domain/quotes/index.ts
@@ -1,0 +1,2 @@
+export { Quote } from './quote';
+export type { QuoteProps, QuoteType, QuoteStatus, QuoteRequest } from './quote';

--- a/src/domain/quotes/quote.ts
+++ b/src/domain/quotes/quote.ts
@@ -1,0 +1,103 @@
+import { Asset, AssetAmount } from '../assets';
+import { BaseEntity, Timestamp, UUID } from '../common';
+
+export type QuoteType = 'buy' | 'sell';
+export type QuoteStatus = 'pending' | 'accepted' | 'expired' | 'rejected';
+
+export interface QuoteProps {
+  id: UUID;
+  type: QuoteType;
+  sourceAsset: Asset;
+  destinationAsset: Asset;
+  sourceAmount: string;
+  destinationAmount: string;
+  price: string; // destination/source ratio
+  fee: string;
+  slippage: string;
+  expirationTime: Timestamp;
+  status: QuoteStatus;
+  createdAt: Timestamp;
+}
+
+export class Quote implements BaseEntity {
+  constructor(
+    public readonly id: UUID,
+    public readonly type: QuoteType,
+    public readonly sourceAsset: Asset,
+    public readonly destinationAsset: Asset,
+    public readonly sourceAmount: string,
+    public readonly destinationAmount: string,
+    public readonly price: string,
+    public readonly fee: string,
+    public readonly slippage: string,
+    public readonly expirationTime: Timestamp,
+    public readonly status: QuoteStatus,
+    public readonly createdAt: Timestamp,
+    public readonly updatedAt: Timestamp,
+    public readonly version: number
+  ) {}
+
+  getSourceAmountObject(): AssetAmount {
+    return AssetAmount.create(this.sourceAsset, this.sourceAmount);
+  }
+
+  getDestinationAmountObject(): AssetAmount {
+    return AssetAmount.create(this.destinationAsset, this.destinationAmount);
+  }
+
+  isExpired(): boolean {
+    return new Date(this.expirationTime) < new Date();
+  }
+
+  accept(): Quote {
+    if (this.status !== 'pending') {
+      throw new Error(`Cannot accept quote with status ${this.status}`);
+    }
+    if (this.isExpired()) {
+      throw new Error('Cannot accept expired quote');
+    }
+    return new Quote(
+      this.id,
+      this.type,
+      this.sourceAsset,
+      this.destinationAsset,
+      this.sourceAmount,
+      this.destinationAmount,
+      this.price,
+      this.fee,
+      this.slippage,
+      this.expirationTime,
+      'accepted',
+      this.createdAt,
+      new Date().toISOString(),
+      this.version + 1
+    );
+  }
+
+  reject(): Quote {
+    return new Quote(
+      this.id,
+      this.type,
+      this.sourceAsset,
+      this.destinationAsset,
+      this.sourceAmount,
+      this.destinationAmount,
+      this.price,
+      this.fee,
+      this.slippage,
+      this.expirationTime,
+      'rejected',
+      this.createdAt,
+      new Date().toISOString(),
+      this.version + 1
+    );
+  }
+}
+
+export interface QuoteRequest {
+  sourceAsset: Asset;
+  destinationAsset: Asset;
+  sourceAmount?: string;
+  destinationAmount?: string;
+  slippageTolerance?: string;
+}

--- a/src/domain/routing/index.ts
+++ b/src/domain/routing/index.ts
@@ -1,0 +1,2 @@
+export { Path } from './path';
+export type { PathNode, PathEdge, PathProps, PathRequest } from './path';

--- a/src/domain/routing/path.ts
+++ b/src/domain/routing/path.ts
@@ -1,0 +1,65 @@
+import { Asset, AssetAmount } from '../assets';
+import { BaseEntity, UUID } from '../common';
+
+export interface PathNode {
+  asset: Asset;
+  amount: string;
+  price: string;
+}
+
+export interface PathEdge {
+  from: Asset;
+  to: Asset;
+  price: string;
+  liquidity: string;
+  exchangeId: string;
+}
+
+export interface PathProps {
+  id: UUID;
+  sourceAmount: AssetAmount;
+  destinationAmount: AssetAmount;
+  nodes: PathNode[];
+  edges: PathEdge[];
+  totalFee: string;
+  estimatedTime: number; // milliseconds
+}
+
+export class Path implements BaseEntity {
+  constructor(
+    public readonly id: UUID,
+    public readonly sourceAmount: AssetAmount,
+    public readonly destinationAmount: AssetAmount,
+    public readonly nodes: PathNode[],
+    public readonly edges: PathEdge[],
+    public readonly totalFee: string,
+    public readonly estimatedTime: number,
+    public readonly createdAt: string,
+    public readonly updatedAt: string,
+    public readonly version: number
+  ) {}
+
+  getHopCount(): number {
+    return this.nodes.length;
+  }
+
+  getPriceImpact(): string {
+    if (this.nodes.length === 0) return '0';
+    const firstPrice = parseFloat(this.nodes[0].price);
+    const lastPrice = parseFloat(this.nodes[this.nodes.length - 1].price);
+    return ((lastPrice - firstPrice) / firstPrice * 100).toString();
+  }
+
+  toString(): string {
+    const pathString = this.nodes.map(node => node.asset.code).join(' → ');
+    return `${pathString}: ${this.sourceAmount.amount} → ${this.destinationAmount.amount}`;
+  }
+}
+
+export interface PathRequest {
+  sourceAsset: Asset;
+  destinationAsset: Asset;
+  amount: string;
+  maxHops?: number;
+  preferLiquidity?: boolean;
+}


### PR DESCRIPTION
## Description
Replaces freeform strings and ad hoc objects with shared domain types across tools and services.

## Changes Made

### Domain Models Created

#### Common (`src/domain/common/`)
- ✅ BaseEntity interface with id, createdAt, updatedAt, version
- ✅ Result pattern for error handling
- ✅ Pagination types (PaginatedResult, PaginationParams)
- ✅ ValueObject base class for immutability
- ✅ Domain-specific errors (ValidationError, InsufficientBalanceError, AssetNotFoundError, InvalidAmountError)
- ✅ Validators for amounts, addresses, asset codes

#### Assets (`src/domain/assets/`)
- ✅ Asset class supporting native (XLM) and custom assets
- ✅ AssetAmount value object with add/subtract/comparison operations
- ✅ Type-safe asset operations

#### Balances (`src/domain/balances/`)
- ✅ Balance entity with available balance calculation
- ✅ BalanceSnapshot for point-in-time views
- ✅ BalanceMap for multi-asset portfolio management

#### Quotes (`src/domain/quotes/`)
- ✅ Quote entity with status workflow (pending/accepted/expired/rejected)
- ✅ QuoteRequest type for quote generation
- ✅ Price, fee, and slippage tracking

#### Routing/Paths (`src/domain/routing/`)
- ✅ Path class with nodes and edges
- ✅ Price impact calculation
- ✅ PathRequest for route finding

## Files Added
- `src/domain/common/` - Base types, errors, validators
- `src/domain/assets/` - Asset and AssetAmount models
- `src/domain/balances/` - Balance and BalanceSnapshot
- `src/domain/quotes/` - Quote and QuoteRequest
- `src/domain/routing/` - Path and PathRequest
- `src/domain/__tests__/` - Unit tests

Closes #339