### PR TITLE
feat: add Discord slash commands, deprecate legacy ! prefix

### DIFF
--- a/packages/bot/src/adapters/discord.ts
+++ b/packages/bot/src/adapters/discord.ts
@@ -3,12 +3,15 @@ import {
   GatewayIntentBits,
   Message,
   TextChannel,
-  ThreadChannel,
   ChannelType,
-  TextBasedChannel,
   ActivityType,
   GuildMember,
+  ChatInputCommandInteraction,
+  Interaction,
+  REST,
+  Routes,
 } from "discord.js";
+import { slashCommandDefinitions } from "../slashCommands";
 import { TransactionNotificationData, PriceAlert, TrendingAsset } from "../types";
 import {
   createTrustlineOperation,
@@ -252,6 +255,26 @@ export class DiscordAdapter {
     }, initialDelay);
   }
 
+  // Register slash commands with Discord via REST API
+  async deploySlashCommands(): Promise<void> {
+    const token = process.env.DISCORD_BOT_TOKEN || this.token;
+    const clientId = process.env.DISCORD_CLIENT_ID;
+    if (!token || !clientId) {
+      console.warn("⚠️ Discord: DISCORD_CLIENT_ID or token missing, skipping slash command deployment.");
+      return;
+    }
+    const rest = new REST({ version: "10" }).setToken(token);
+    try {
+      console.log("🔄 Deploying slash commands...");
+      await rest.put(Routes.applicationCommands(clientId), {
+        body: slashCommandDefinitions,
+      });
+      console.log(`✅ Deployed ${slashCommandDefinitions.length} slash commands.`);
+    } catch (error) {
+      console.error("❌ Failed to deploy slash commands:", error);
+    }
+  }
+
   async init() {
     const token = process.env.DISCORD_BOT_TOKEN || this.token;
     if (!token) {
@@ -273,12 +296,25 @@ export class DiscordAdapter {
       });
     });
 
+    // Slash command interaction handler
+    this.client.on("interactionCreate", async (interaction: Interaction) => {
+      if (!interaction.isChatInputCommand()) return;
+      await this.handleSlashCommand(interaction);
+    });
+
     this.client.on("messageCreate", withPerformanceProfiling(
       'messageCreate',
       'discord',
       'system',
       async (message: Message) => {
         if (message.author.bot) return;
+
+        // Legacy ! prefix commands are deprecated. Please use slash commands (/) instead.
+        const isLegacyCommand = message.content.startsWith('!');
+        if (isLegacyCommand) {
+          await message.reply('⚠️ **Deprecation Notice:** `!` prefix commands are deprecated. Please use `/` slash commands instead (e.g. `/help`, `/ping`).');
+          return;
+        }
 
         // #124: Scan for scam links in public channels
         if (this.shouldScanForScams(message)) {
@@ -635,10 +671,255 @@ export class DiscordAdapter {
     }));
 
     await this.client.login(token);
+    await this.deploySlashCommands();
     this.startAlertPolling();
     // #128: Start market overview scheduler
     this.startMarketOverviewScheduler();
     console.log("✅ Discord bot initialized.");
+  }
+
+  // Route slash command interactions to the appropriate handler
+  private async handleSlashCommand(interaction: ChatInputCommandInteraction): Promise<void> {
+    const userId = interaction.user.id;
+    const cmd = interaction.commandName;
+
+    // Anti-flood check
+    if (this.isFlooding(userId)) {
+      await interaction.reply({ content: "⏳ Please wait a moment before sending another command.", ephemeral: true });
+      return;
+    }
+
+    // Rate limit check
+    const rateLimitResult = this.checkRateLimit(userId, `/${cmd}`);
+    if (!rateLimitResult.allowed) {
+      await interaction.reply({ content: rateLimitResult.message ?? "⏳ Rate limit exceeded.", ephemeral: true });
+      return;
+    }
+
+    await withPerformanceProfiling(`/${cmd}`, 'discord', userId, async () => {
+      switch (cmd) {
+        case "start":
+          await interaction.reply("Welcome to Chen Pilot! I am your AI-powered Stellar DeFi assistant. Type `/help` to see what I can do!");
+          break;
+
+        case "ping": {
+          await interaction.deferReply();
+          const startTime = Date.now();
+          try {
+            const controller = new AbortController();
+            const timeout = setTimeout(() => controller.abort(), 5000);
+            const response = await fetch(`${BACKEND_URL}/api/health`, { method: "GET", signal: controller.signal });
+            clearTimeout(timeout);
+            const ms = Date.now() - startTime;
+            await interaction.editReply(
+              response.ok
+                ? `🏓 **Pong!**\n\n📡 **End-to-End Latency:** ${ms}ms\n✅ Backend: Online`
+                : `🏓 **Pong!**\n\n📡 **End-to-End Latency:** ${ms}ms\n⚠️ Backend: HTTP ${response.status}`
+            );
+          } catch {
+            await interaction.editReply(`🏓 **Pong!**\n\n📡 **End-to-End Latency:** ${Date.now() - startTime}ms\n❌ Backend: Unreachable`);
+          }
+          break;
+        }
+
+        case "help": {
+          const query = interaction.options.getString("query") ?? "";
+          const results = searchFeatures(query);
+          await interaction.reply(formatHelpMessage(results, query.length > 0, "markdown"));
+          break;
+        }
+
+        case "thread": {
+          if (interaction.channel?.type === ChannelType.GuildText) {
+            try {
+              const thread = await interaction.channel.threads.create({
+                name: `Chen Pilot Session - ${interaction.user.username}`,
+                autoArchiveDuration: 60,
+              });
+              await thread.send(`👋 Hello ${interaction.user.username}! I've started this thread. How can I help you with Stellar DeFi today?`);
+              await interaction.reply({ content: `🧵 Thread created: ${thread}`, ephemeral: true });
+            } catch {
+              await interaction.reply({ content: "❌ Couldn't start a thread. Check my permissions.", ephemeral: true });
+            }
+          } else if (interaction.channel?.isThread()) {
+            await interaction.reply({ content: "🧵 We are already in a thread!", ephemeral: true });
+          } else {
+            await interaction.reply({ content: "❌ Threads can only be started in text channels.", ephemeral: true });
+          }
+          break;
+        }
+
+        case "sponsor": {
+          if (!interaction.channel || interaction.channel.type !== ChannelType.DM) {
+            await interaction.reply({ content: "🔒 This command can only be used in a Direct Message (DM) with the bot.", ephemeral: true });
+            return;
+          }
+          await interaction.deferReply({ ephemeral: true });
+          try {
+            const response = await fetch(`${BACKEND_URL}/api/account/${userId}/sponsor`, { method: "POST", headers: { "Content-Type": "application/json" } });
+            const data = await response.json() as { success: boolean; message: string; address?: string };
+            if (data.success) {
+              await interaction.editReply(`✅ Account sponsored!\n📬 Address: \`${data.address}\``);
+              await this.logAuditAction({ action: "SPONSOR_ACCOUNT", triggeredBy: userId, details: `Address: ${data.address}`, success: true, timestamp: new Date().toISOString() });
+            } else {
+              await interaction.editReply(`❌ Sponsorship failed: ${data.message}`);
+              await this.logAuditAction({ action: "SPONSOR_ACCOUNT", triggeredBy: userId, details: `Failed: ${data.message}`, success: false, timestamp: new Date().toISOString() });
+            }
+          } catch {
+            await interaction.editReply("❌ Could not reach the sponsorship service. Please try again later.");
+          }
+          break;
+        }
+
+        case "trustline": {
+          const assetCode = interaction.options.getString("asset", true);
+          const assetIssuer = interaction.options.getString("issuer", true);
+          await interaction.deferReply();
+          try {
+            const op = await createTrustlineOperation(assetCode, assetIssuer);
+            const issuer = (op as { asset: { issuer: string } }).asset.issuer;
+            const reply = `✅ Found asset **${assetCode}**!\n\n**Asset:** ${assetCode}\n**Issuer:** \`${issuer}\`\n\n*Note: In a future update, I will provide a direct signing link.*`;
+            await interaction.editReply(reply);
+            await this.logAuditAction({ action: "TRUSTLINE_LOOKUP", triggeredBy: userId, details: `Asset: ${assetCode}, Issuer: ${assetIssuer}`, success: true, timestamp: new Date().toISOString() });
+          } catch (error) {
+            await interaction.editReply(`❌ Error: ${error instanceof Error ? error.message : String(error)}`);
+          }
+          break;
+        }
+
+        case "dashboard":
+          await interaction.reply({ content: `📊 **Chen Pilot Dashboard**\n\n🔗 ${DASHBOARD_URL}\n\n*You must be logged in to view the dashboard.*`, ephemeral: true });
+          break;
+
+        case "validate": {
+          const assetCode = interaction.options.getString("asset", true);
+          const issuerAddress = interaction.options.getString("issuer", true);
+          await interaction.deferReply();
+          try {
+            const result = await this.verificationService.verifyAsset(assetCode, issuerAddress);
+            const statusEmoji = result.status === "VERIFIED" ? "✅" : result.status === "MALICIOUS" ? "🚨" : "⚠️";
+            let reply = `${statusEmoji} **Asset Verification: ${result.status}**\n\n**Asset:** ${assetCode}\n**Issuer:** \`${issuerAddress}\`\n`;
+            if (result.domain) reply += `**Domain:** ${result.domain}\n`;
+            if (result.details) reply += `**Details:** ${result.details}\n`;
+            reply += `\n**Safe to use:** ${result.isSafe ? "Yes ✅" : "No ❌"}`;
+            await interaction.editReply(reply);
+          } catch (error) {
+            await interaction.editReply(`❌ Verification error: ${error instanceof Error ? error.message : String(error)}`);
+          }
+          break;
+        }
+
+        case "multisig": {
+          if (!interaction.channel || interaction.channel.type !== ChannelType.DM) {
+            await interaction.reply({ content: "🔒 This command can only be used in a Direct Message (DM) with the bot.", ephemeral: true });
+            return;
+          }
+          const response = this.multisigWizard.startWizard(userId, "discord");
+          await interaction.reply({ content: response.message, ephemeral: true });
+          break;
+        }
+
+        case "currency": {
+          const currency = interaction.options.getString("currency", true) as "USD" | "XLM" | "BTC";
+          this.userCurrency.set(userId, currency);
+          await interaction.reply({ content: `✅ Report currency set to **${currency}**`, ephemeral: true });
+          break;
+        }
+
+        case "report": {
+          const currency = this.userCurrency.get(userId) ?? "USD";
+          await interaction.deferReply({ ephemeral: true });
+          try {
+            const res = await fetch(`${BACKEND_URL}/api/portfolio/${userId}?currency=${currency}`);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const data = await res.json() as { totalValue: number; assets: { code: string; balance: number; value: number }[] };
+            let reply = `📊 **Portfolio Report (${currency})**\n\n**Total Value:** ${data.totalValue.toFixed(4)} ${currency}\n\n`;
+            for (const a of data.assets) {
+              reply += `• **${a.code}**: ${a.balance} ≈ ${a.value.toFixed(4)} ${currency}\n`;
+            }
+            await interaction.editReply(reply);
+          } catch {
+            await interaction.editReply("❌ Could not fetch portfolio. Make sure your account is registered.");
+          }
+          break;
+        }
+
+        case "alert": {
+          const assetCode = interaction.options.getString("asset", true).toUpperCase();
+          const condition = interaction.options.getString("condition", true) as "above" | "below";
+          const targetPrice = interaction.options.getNumber("price", true);
+          const currency = (interaction.options.getString("currency") ?? this.userCurrency.get(userId) ?? "USD") as "USD" | "XLM" | "BTC";
+          const alertId = `${userId}-${assetCode}-${Date.now()}`;
+          const alert: PriceAlert = { id: alertId, userId, assetCode, targetPrice, currency, condition, createdAt: new Date().toISOString(), triggered: false };
+          this.priceAlerts.set(alertId, alert);
+          if (!this.userChannels.has(userId)) this.userChannels.set(userId, interaction.channelId);
+          await interaction.reply({ content: `🔔 Alert set: notify me when **${assetCode}** is ${condition} **${targetPrice} ${currency}**`, ephemeral: true });
+          break;
+        }
+
+        case "alerts": {
+          const userAlerts = [...this.priceAlerts.values()].filter(a => a.userId === userId && !a.triggered);
+          if (!userAlerts.length) {
+            await interaction.reply({ content: "📭 You have no active price alerts. Use `/alert` to set one.", ephemeral: true });
+            return;
+          }
+          let reply = "🔔 **Your Active Alerts**\n\n";
+          for (const a of userAlerts) {
+            reply += `• **${a.assetCode}** ${a.condition} ${a.targetPrice} ${a.currency} (ID: \`${a.id.slice(-6)}\`)\n`;
+          }
+          await interaction.reply({ content: reply, ephemeral: true });
+          break;
+        }
+
+        case "advanced": {
+          if (!interaction.member || !interaction.guild) {
+            await interaction.reply({ content: "❌ This command must be used in a server.", ephemeral: true });
+            return;
+          }
+          const member = await interaction.guild.members.fetch(userId);
+          const hasRole = member.roles.cache.some((r: { name: string }) => ADVANCED_ROLE_NAMES.includes(r.name));
+          if (!hasRole) {
+            await interaction.reply({ content: `🔒 This command requires one of the following roles: **${ADVANCED_ROLE_NAMES.join(", ")}**`, ephemeral: true });
+            return;
+          }
+          await interaction.reply({ content: "✅ Advanced command executed. (Role check passed)", ephemeral: true });
+          break;
+        }
+
+        case "discover": {
+          if (!interaction.member || !interaction.guild) {
+            await interaction.reply({ content: "❌ This command must be used in a server.", ephemeral: true });
+            return;
+          }
+          const member = await interaction.guild.members.fetch(userId);
+          const hasRole = member.roles.cache.some((r: { name: string }) => ADVANCED_ROLE_NAMES.includes(r.name));
+          if (!hasRole) {
+            await interaction.reply({ content: `🔒 \`/discover\` requires one of the following roles: **${ADVANCED_ROLE_NAMES.join(", ")}**`, ephemeral: true });
+            return;
+          }
+          await interaction.deferReply();
+          try {
+            const res = await fetch(`${BACKEND_URL}/api/assets/trending`);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const assets = await res.json() as TrendingAsset[];
+            if (!assets.length) { await interaction.editReply("📭 No trending assets found at this time."); return; }
+            let reply = "🌟 **Trending Stellar Assets**\n\n";
+            for (const a of assets.slice(0, 5)) {
+              const change = a.priceChange24h >= 0 ? `+${a.priceChange24h.toFixed(2)}%` : `${a.priceChange24h.toFixed(2)}%`;
+              const emoji = a.priceChange24h >= 0 ? "📈" : "📉";
+              reply += `${emoji} **${a.assetCode}**${a.domain ? ` (${a.domain})` : ""}\n  24h Change: ${change} | Volume: ${a.volume24h.toLocaleString()} | Holders: ${a.holders.toLocaleString()}\n\n`;
+            }
+            await interaction.editReply(reply);
+          } catch {
+            await interaction.editReply("❌ Could not fetch trending assets. Please try again later.");
+          }
+          break;
+        }
+
+        default:
+          await interaction.reply({ content: "❓ Unknown command.", ephemeral: true });
+      }
+    })();
   }
 
   // #120: Check if message author has an advanced role

--- a/packages/bot/src/slashCommands.ts
+++ b/packages/bot/src/slashCommands.ts
@@ -1,0 +1,161 @@
+import {
+  SlashCommandBuilder,
+  SlashCommandStringOption,
+  SlashCommandNumberOption,
+  RESTPostAPIChatInputApplicationCommandsJSONBody,
+} from "discord.js";
+
+export const slashCommandDefinitions: RESTPostAPIChatInputApplicationCommandsJSONBody[] =
+  [
+    new SlashCommandBuilder()
+      .setName("start")
+      .setDescription("Welcome message and bot introduction")
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("ping")
+      .setDescription("Check bot latency and backend health")
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("help")
+      .setDescription("List available features or search for a specific one")
+      .addStringOption((opt: SlashCommandStringOption) =>
+        opt
+          .setName("query")
+          .setDescription("Search term to filter features")
+          .setRequired(false)
+      )
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("thread")
+      .setDescription("Start a dedicated support thread in this channel")
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("sponsor")
+      .setDescription(
+        "Request free Stellar account sponsorship (DM only for security)"
+      )
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("trustline")
+      .setDescription("Look up a Stellar asset trustline")
+      .addStringOption((opt: SlashCommandStringOption) =>
+        opt
+          .setName("asset")
+          .setDescription("Asset code, e.g. USDC")
+          .setRequired(true)
+      )
+      .addStringOption((opt: SlashCommandStringOption) =>
+        opt
+          .setName("issuer")
+          .setDescription("Issuer domain or address, e.g. circle.com")
+          .setRequired(true)
+      )
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("dashboard")
+      .setDescription("Get a link to the Chen Pilot admin dashboard")
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("validate")
+      .setDescription("Verify a Stellar asset for safety")
+      .addStringOption((opt: SlashCommandStringOption) =>
+        opt
+          .setName("asset")
+          .setDescription("Asset code, e.g. USDC")
+          .setRequired(true)
+      )
+      .addStringOption((opt: SlashCommandStringOption) =>
+        opt
+          .setName("issuer")
+          .setDescription("Issuer address (Stellar public key)")
+          .setRequired(true)
+      )
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("multisig")
+      .setDescription("Start the multi-signature wallet setup wizard (DM only)")
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("currency")
+      .setDescription("Set your preferred reporting currency")
+      .addStringOption((opt: SlashCommandStringOption) =>
+        opt
+          .setName("currency")
+          .setDescription("Currency to use for reports")
+          .setRequired(true)
+          .addChoices(
+            { name: "USD", value: "USD" },
+            { name: "XLM", value: "XLM" },
+            { name: "BTC", value: "BTC" }
+          )
+      )
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("report")
+      .setDescription("Get your portfolio report in your preferred currency")
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("alert")
+      .setDescription("Set a price alert for a Stellar asset")
+      .addStringOption((opt: SlashCommandStringOption) =>
+        opt
+          .setName("asset")
+          .setDescription("Asset code, e.g. XLM")
+          .setRequired(true)
+      )
+      .addStringOption((opt: SlashCommandStringOption) =>
+        opt
+          .setName("condition")
+          .setDescription("Trigger condition")
+          .setRequired(true)
+          .addChoices(
+            { name: "above", value: "above" },
+            { name: "below", value: "below" }
+          )
+      )
+      .addNumberOption((opt: SlashCommandNumberOption) =>
+        opt
+          .setName("price")
+          .setDescription("Target price")
+          .setRequired(true)
+          .setMinValue(0)
+      )
+      .addStringOption((opt: SlashCommandStringOption) =>
+        opt
+          .setName("currency")
+          .setDescription("Currency for the price (defaults to your set currency)")
+          .setRequired(false)
+          .addChoices(
+            { name: "USD", value: "USD" },
+            { name: "XLM", value: "XLM" },
+            { name: "BTC", value: "BTC" }
+          )
+      )
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("alerts")
+      .setDescription("List your active price alerts")
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("advanced")
+      .setDescription("Execute an advanced role-gated command")
+      .toJSON(),
+
+    new SlashCommandBuilder()
+      .setName("discover")
+      .setDescription("Discover trending Stellar assets (requires advanced role)")
+      .toJSON(),
+  ];


### PR DESCRIPTION
 feat: add Discord slash commands, deprecate legacy ! prefix
  
  Migrates the Discord bot adapter from legacy message prefix commands (!) to native Discord
  slash commands (/).
  
  Changes:
  
  - slashCommands.ts — new file defining all 15 slash command schemas using SlashCommandBuilder
   with typed options, choices, and required flags
  - discord.ts — adds deploySlashCommands() which registers commands via Discord REST API on
  startup (requires DISCORD_CLIENT_ID env var); adds interactionCreate handler routing to a new
  handleSlashCommand() switch; legacy messageCreate handler now returns a deprecation notice for
  any ! prefixed message
  
  Commands migrated: /start, /ping, /help, /thread, /sponsor, /trustline, /dashboard, /validate,
  /multisig, /currency, /report, /alert, /alerts, /advanced, /discover
  
  Notes:
  
  - Sensitive commands (/sponsor, /multisig) enforce DM-only via ephemeral replies in guild
  channels
  - Async commands use deferReply/editReply to avoid Discord's 3-second interaction timeout
  - Role-gated commands (/advanced, /discover) fetch guild member roles at interaction time
  - Existing rate limiting and flood protection apply to slash commands unchanged
closes #107